### PR TITLE
Refactoring frame timing

### DIFF
--- a/base/src/main/java/com/avogine/Avogine.java
+++ b/base/src/main/java/com/avogine/Avogine.java
@@ -11,7 +11,6 @@ import com.avogine.logging.*;
  * <p>
  * To kick off the game loop, create a new {@link Avogine} and supply it with a {@link Window} to render
  * to and a {@link Game} to run, then call {@link #start()}.
- * @author Dominus
  *
  */
 public class Avogine implements Runnable {
@@ -26,19 +25,17 @@ public class Avogine implements Runnable {
 	 * Target updates per second. Controls how often game logic is run in a single second.
 	 */
 	public static final int TARGET_UPS = 60;
+	
+	private static final long SLEEP_PRECISION = TimeUnit.MILLISECONDS.toNanos(2);
 
 	private final Thread gameLoopThread;
 	
 	private final Window window;
 	private final Game game;
 	
-	private final Timer timer;
 	private final Input input;
+	private final Timer timer;
 	
-	private float frameTime;
-	private int fps;
-	private float sleepRemainder;
-		
 	/**
 	 * @param window The primary game {@link Window} to display to
 	 * @param game An implementation of {@link Game} that contains the main game logic
@@ -47,9 +44,9 @@ public class Avogine implements Runnable {
 		gameLoopThread = new Thread(this, "GAME_LOOP_THREAD");
 		this.window = window;
 		this.game = game;
-		timer = new Timer();
 		// TODO Add an additional constructor for custom Input implementations as well, maybe even Timer? But idc right now.
 		input = new Input();
+		timer = new Timer();
 	}
 	
 	/**
@@ -85,113 +82,89 @@ public class Avogine implements Runnable {
 		window.init(input);
 		game.init(window);
 		timer.init();
-		
-		// XXX This sort of works, but only when the window is resized, not while it's being moved/held
-//		GLFW.glfwSetWindowRefreshCallback(window.getId(), (window) -> {
-//			logger.info("Refreshing");
-//			
-//			update(0.045f);
-//			
-//			fps++;
-//			if (frameTime >= 1.0f) {
-//				window.setFps(fps);
-//				frameTime = 0;
-//				fps = 0;
-//			}
-//			stage.render(window);
-//			
-//			GLFW.glfwSwapBuffers(window);
-//		});
-		
 	}
 	
-	/**
-	 * Call once to kick off game loop.
-	 * <p>
-	 * Runs as long as {@link #window} is not set to close.
-	 * <p>
-	 * In order, once per frame the {@link #frameTime} is calculated, input is processed, update code is run, the screen is rendered, and then also synced to the target framerate.
-	 */
 	private void loop() {
-		float elapsedTime;
-//		float accumulator = 0f;
-//		float interval = 1f / TARGET_UPS;
+		double renderInterval = 1.0 / TARGET_FPS;
+		double updateInterval = 1.0 / TARGET_UPS;
 		
+		double previousFrameTime = timer.getTime();
+		double accumulator = 0.0;
+				
 		while (!window.shouldClose()) {
-			// XXX Minor hack to limit frame updates when the window is "held" and instead tie pauses to at least the target UPS
-//			elapsedTime = Math.min(interval, timer.getElapsedTime());
-			elapsedTime = timer.getElapsedTime();
-			frameTime += elapsedTime;
-
+			double frameStartTime = timer.getTime();
+			double elapsedTime = (frameStartTime - previousFrameTime);
+			window.setFps((int) (1 / elapsedTime));
+			accumulator += elapsedTime;
+			
 			input();
-
-			update(elapsedTime);
+			
+			while (accumulator > updateInterval) {
+				update((float) updateInterval);
+				accumulator -= updateInterval;
+			}
 			
 			render();
+
+			previousFrameTime = frameStartTime;
+			// Get the time it took to actually process the entire frame (this should be counted as a segment of our overall time dictated by renderInterval)
+			double frameProcessTimeNanos = timer.getTime() - frameStartTime;
+			long sleepTime = (long) (Math.max(renderInterval - frameProcessTimeNanos, 0) * 1_000_000_000); // Convert to nanoseconds
 			
-			// XXX Should syncing occur at the start of the frame? If a frame takes a long time to render/process, by the time we get here we could've already surpassed our frame time budget
-			sync();
-		}
-		
-		// XXX Updates with a constant delta time, but blows up if frame rate is consistently low
-//		while (!window.shouldClose()) {
-//			// XXX Minor hack to limit frame updates when the window is "held" and instead tie pauses to at least the target UPS
-//			elapsedTime = Math.min(interval, timer.getElapsedTime());
-//			accumulator += elapsedTime;
-//			frameTime += elapsedTime;
-//
-//			input();
-//
-//			while (accumulator >= interval) {
-//				update(interval);
-//				accumulator -= interval;
-//			}
-//			
-//			render();
-//			
-//			// XXX Should syncing occur at the start of the frame? If a frame takes a long time to render/process, by the time we get here we could've already surpassed our frame time budget
-//			sync();
-//		}
-	}
-	
-	private void input() {
-		input.update();
-	}
-	
-	private void render() {
-		if (frameTime >= 1.0f) {
-			window.setFps(fps);
-//			logger.info("FPS: {}", fps);
-			frameTime = 0;
-			fps = 0;
-		}
-		fps++;
-		
-		game.render();
-		window.update();
-	}
-	
-	private void update(float interval) {
-		// TODO Process EventQueue
-		game.update(interval);
-	}
-	
-	private void sync() {
-		float loopSlot = 1f / TARGET_FPS;
-		double endTime = timer.getLastLoopTime() + loopSlot + sleepRemainder;
-		
-		// Time values are seconds based, so we're subtracting 0.001 to make sure we won't try sleeping for fractions of milliseconds
-		while (timer.getTime() < endTime - 0.001) {
 			try {
-				Thread.sleep(1);
+				sleepNanos(sleepTime);
 			} catch (InterruptedException e) {
 				AvoLog.log().warn("Sync operation was interrupted?", e);
 				Thread.currentThread().interrupt();
 			}
 		}
-		// If there is any time left over, save it for the next sync
-		// This ensures high precision when picking frame rate targets
-		sleepRemainder = (float) Math.max(0, endTime - timer.getTime());
+	}
+	
+	private void input() {
+		input.update();
+	}
+
+	private void update(float interval) {
+		// TODO Process EventQueue
+		game.update(interval);
+	}
+	
+	private void render() {
+		game.render();
+		window.update();
+	}
+	
+	/**
+	 * Perform regular {@link Thread#sleep()} while the remaining sleep duration is greater than {@code Avogine.SLEEP_PRECISION}.
+	 * If the remaining time is less than {@code Avogine.SLEEP_PRECISION} then perform a {@link Thread#onSpinWait()} for the remainder of the time.
+	 * </p>
+	 * This method is preferable than just relying on {@code Thread.sleep()} since not only does {@code Thread.sleep()} not support sleeping for less
+	 * than a millisecond on Windows, but also because there's about a 1-2ms error rate on waking from the sleep so using a busy wait loop allows us
+	 * to more quickly recover from smaller sleep durations.
+	 * 
+	 * @see <a href="http://andy-malakov.blogspot.com/2010/06/alternative-to-threadsleep.html">http://andy-malakov.blogspot.com/2010/06/alternative-to-threadsleep.html</a>
+	 * 
+	 * @param nanoDuration The amount of time to sleep for in nanoseconds.
+	 * @throws InterruptedException
+	 */
+	private static void sleepNanos(long nanoDuration) throws InterruptedException {
+		final long end = System.nanoTime() + nanoDuration;
+
+		long timeLeft = nanoDuration;
+		do {
+			if (timeLeft > SLEEP_PRECISION)
+				Thread.sleep(1);
+			else {
+				// Potentially opt instead for spin waiting while greater than some other spin_yield_precision value
+				Thread.onSpinWait();
+			}
+			
+			timeLeft = end - System.nanoTime();
+			
+			if (Thread.interrupted()) {
+				throw new InterruptedException();
+			}
+		} while (timeLeft > 0);
 	}
 	
 	private void cleanup() {

--- a/base/src/main/java/com/avogine/Avogine.java
+++ b/base/src/main/java/com/avogine/Avogine.java
@@ -16,12 +16,6 @@ import com.avogine.logging.*;
 public class Avogine implements Runnable {
 
 	/**
-	 * TODO This needs to be customizable/read from a property.
-	 * Target frames per second. Controls how often the screen is rendered in a single second.
-	 */
-	public static final int TARGET_FPS = 144;
-
-	/**
 	 * Target updates per second. Controls how often game logic is run in a single second.
 	 */
 	public static final int TARGET_UPS = 60;
@@ -85,7 +79,6 @@ public class Avogine implements Runnable {
 	}
 	
 	private void loop() {
-		double renderInterval = 1.0 / TARGET_FPS;
 		double updateInterval = 1.0 / TARGET_UPS;
 		
 		double previousFrameTime = timer.getTime();
@@ -109,7 +102,7 @@ public class Avogine implements Runnable {
 			previousFrameTime = frameStartTime;
 			// Get the time it took to actually process the entire frame (this should be counted as a segment of our overall time dictated by renderInterval)
 			double frameProcessTimeNanos = timer.getTime() - frameStartTime;
-			long sleepTime = (long) (Math.max(renderInterval - frameProcessTimeNanos, 0) * 1_000_000_000); // Convert to nanoseconds
+			long sleepTime = (long) (Math.max(window.getTargetFps() - frameProcessTimeNanos, 0) * 1_000_000_000); // Convert to nanoseconds
 			
 			try {
 				sleepNanos(sleepTime);

--- a/base/src/main/java/com/avogine/game/Timer.java
+++ b/base/src/main/java/com/avogine/game/Timer.java
@@ -1,41 +1,28 @@
 package com.avogine.game;
 
+import org.lwjgl.glfw.*;
+
 /**
- *
+ * A wrapper class for managing calls to GLFW's time methods.
  */
 public class Timer {
 
-	private double lastLoopTime;
-
 	/**
-	 * 
+	 * Initialize the GLFW system timer.
+	 * </p>
+	 * This should largely be viewed as a convenience as the timer automatically gets initialized to 0
+	 * when {@link GLFW#glfwInit()} is called.
 	 */
 	public void init() {
-		lastLoopTime = getTime();
+		GLFW.glfwSetTime(0.0);
 	}
 
 	/**
-	 * @return
+	 * Returns the current time in seconds since {@link #init()} was called.
+	 * @return the current time in seconds since {@link #init()} was called.
 	 */
 	public double getTime() {
-		return System.nanoTime() / 1000_000_000.0;
+		return GLFW.glfwGetTime();
 	}
 
-	/**
-	 * @return
-	 */
-	public float getElapsedTime() {
-		double time = getTime();
-		float elapsedTime = (float) (time - lastLoopTime);
-		lastLoopTime = time;
-		return elapsedTime;
-	}
-
-	/**
-	 * @return
-	 */
-	public double getLastLoopTime() {
-		return lastLoopTime;
-	}
-	
 }

--- a/base/src/main/java/com/avogine/game/ui/nuklear/AvoNuklear.java
+++ b/base/src/main/java/com/avogine/game/ui/nuklear/AvoNuklear.java
@@ -27,13 +27,12 @@ import com.avogine.util.resource.*;
  */
 public class AvoNuklear {
 
-	private static final NkAllocator ALLOCATOR;
-
-	static {
-		ALLOCATOR = NkAllocator.create()
-				.alloc((handle, old, size) -> nmemAllocChecked(size))
-				.mfree((handle, ptr) -> nmemFree(ptr));
-	}
+	/**
+	 * Nuklear Allocator struct for managing all Nuklear related memory allocations.
+	 */
+	public static final NkAllocator ALLOCATOR = NkAllocator.create()
+			.alloc((handle, old, size) -> nmemAllocChecked(size))
+			.mfree((handle, ptr) -> nmemFree(ptr));
 	
 	// Storage for font data
 	private final ByteBuffer ttf;

--- a/base/src/main/java/com/avogine/io/Window.java
+++ b/base/src/main/java/com/avogine/io/Window.java
@@ -26,12 +26,16 @@ import com.avogine.util.*;
  */
 public class Window {
 
+	private static final int TARGET_FPS_FOCUS = 144;
+	private static final int TARGET_FPS_BACKGROUND = 30;
+	
 	private long id;
 	
 	private int width;
 	private int height;
 	private String title;
 	
+	private double targetFPS;
 	private int fps;
 	
 	private WindowProperties properties;
@@ -70,6 +74,7 @@ public class Window {
 		GLFW.glfwWindowHint(GLFW.GLFW_VISIBLE, GLFW.GLFW_FALSE);
 		GLFW.glfwWindowHint(GLFW.GLFW_RESIZABLE, GLFW.GLFW_TRUE);
 		GLFW.glfwWindowHint(GLFW.GLFW_SAMPLES, 4);
+		GLFW.glfwWindowHint(GLFW.GLFW_FOCUS_ON_SHOW, GLFW.GLFW_TRUE);
 //		GLFW.glfwWindowHint(GLFW.GLFW_DECORATED, GLFW.GLFW_FALSE);
 //		GLFW.glfwWindowHint(GLFW.GLFW_FLOATING, GLFW.GLFW_TRUE);
 //		GLFW.glfwWindowHint(GLFW.GLFW_TRANSPARENT_FRAMEBUFFER, GLFW.GLFW_TRUE);
@@ -116,6 +121,9 @@ public class Window {
 		if (GLFW.glfwGetWindowAttrib(id, GLFW.GLFW_TRANSPARENT_FRAMEBUFFER) == GLFW.GLFW_TRUE) {
 			GLFW.glfwSetWindowOpacity(id, 0.5f);
 		}
+		
+		targetFPS = 1.0 / TARGET_FPS_FOCUS;
+		GLFW.glfwSetWindowFocusCallback(id, (window, focused) -> targetFPS = 1.0 / (focused ? TARGET_FPS_FOCUS : TARGET_FPS_BACKGROUND));
 		
 		GLFW.glfwShowWindow(id);
 
@@ -262,6 +270,16 @@ public class Window {
 	 */
 	public Input getInput() {
 		return input;
+	}
+	
+	/**
+	 * Return target frames per second. Controls how often the screen is rendered in a single second.
+	 * </p>
+	 * TODO This needs to be customizable/read from a property.
+	 * @return target frames per second. Controls how often the screen is rendered in a single second.
+	 */
+	public double getTargetFps() {
+		return targetFPS;
 	}
 	
 	public int getFps() {

--- a/log/src/main/resources/log4j2.properties
+++ b/log/src/main/resources/log4j2.properties
@@ -14,32 +14,32 @@ appender.console.layout.type = PatternLayout
 appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss} %-5p %c:%L - %m%n
 
 # RollingFileAppender name, pattern, path and rollover policy
-appender.rolling.type = RollingFile
-appender.rolling.name = fileLogger
-appender.rolling.fileName= ${basePath}/avo.log
-appender.rolling.filePattern= ${basePath}/app_%d{yyyyMMdd}.log.gz
-appender.rolling.layout.type = PatternLayout
-appender.rolling.layout.pattern = %d{yyyy-MM-dd HH:mm:ss.SSS} %level [%t] [%l] - %msg%n
-appender.rolling.policies.type = Policies
-
-# RollingFileAppender rotation policy
-appender.rolling.policies.size.type = SizeBasedTriggeringPolicy
-appender.rolling.policies.size.size = 10MB
-appender.rolling.policies.time.type = TimeBasedTriggeringPolicy
-appender.rolling.policies.time.interval = 1
-appender.rolling.policies.time.modulate = true
-appender.rolling.strategy.type = DefaultRolloverStrategy
-appender.rolling.strategy.delete.type = Delete
-appender.rolling.strategy.delete.basePath = ${basePath}
-appender.rolling.strategy.delete.maxDepth = 10
-appender.rolling.strategy.delete.ifLastModified.type = IfLastModified
-
-# Delete all files older than 30 days
-appender.rolling.strategy.delete.ifLastModified.age = 30d
+#appender.rolling.type = RollingFile
+#appender.rolling.name = fileLogger
+#appender.rolling.fileName= ${basePath}/avo.log
+#appender.rolling.filePattern= ${basePath}/app_%d{yyyyMMdd}.log.gz
+#appender.rolling.layout.type = PatternLayout
+#appender.rolling.layout.pattern = %d{yyyy-MM-dd HH:mm:ss.SSS} %level [%t] [%l] - %msg%n
+#appender.rolling.policies.type = Policies
+#
+## RollingFileAppender rotation policy
+#appender.rolling.policies.size.type = SizeBasedTriggeringPolicy
+#appender.rolling.policies.size.size = 10MB
+#appender.rolling.policies.time.type = TimeBasedTriggeringPolicy
+#appender.rolling.policies.time.interval = 1
+#appender.rolling.policies.time.modulate = true
+#appender.rolling.strategy.type = DefaultRolloverStrategy
+#appender.rolling.strategy.delete.type = Delete
+#appender.rolling.strategy.delete.basePath = ${basePath}
+#appender.rolling.strategy.delete.maxDepth = 10
+#appender.rolling.strategy.delete.ifLastModified.type = IfLastModified
+#
+## Delete all files older than 30 days
+#appender.rolling.strategy.delete.ifLastModified.age = 30d
 
 # Root logger level
 rootLogger.level = debug
 # Root logger referring to console appender
 rootLogger.appenderRef.stdout.ref = consoleLogger
 # Root logger referring to rolling file appender
-rootLogger.appenderRef.rolling.ref = fileLogger
+#rootLogger.appenderRef.rolling.ref = fileLogger


### PR DESCRIPTION
Timer class implementation refactored to use GLFW time.
Changed main game loop to allow for mismatched update and render
targets, updates should now aim for a fixed time step.
Modified AvoNuklear to have a shared public Allocator object.
Commenting out default log4j2 properties to not include a file log as it
was deleting other project files.