### PR TITLE
Added FrameProfiler

### DIFF
--- a/base/src/main/java/com/avogine/game/ui/nuklear/DebugInfo.java
+++ b/base/src/main/java/com/avogine/game/ui/nuklear/DebugInfo.java
@@ -1,0 +1,47 @@
+package com.avogine.game.ui.nuklear;
+
+import static org.lwjgl.nuklear.Nuklear.*;
+
+import org.lwjgl.nuklear.*;
+import org.lwjgl.system.MemoryStack;
+
+import com.avogine.game.Game;
+import com.avogine.game.util.*;
+
+/**
+ *
+ */
+public class DebugInfo implements UIElement, Renderable {
+
+	private Game game;
+	
+	@Override
+	public void onRegister(Game game) {
+		this.game = game;
+	}
+
+	@Override
+	public void onRender(SceneState sceneState) {
+		var context = game.getGUI().getContext();
+		prepare(context, game.getWindow().getId());
+	}
+
+	@Override
+	public void prepare(NkContext context, long windowId) {
+		try (MemoryStack stack = MemoryStack.stackPush()) {
+			NkStyle style = context.style(); 
+			NkColor background = NkColor.malloc(stack);
+			// Set background to fully transparent layer
+			background.r((byte) 0).g((byte) 0).b((byte) 0).a((byte) 0);
+			style.window().fixed_background().data().color().set(background);
+			
+			NkRect position = NkRect.calloc(stack).x(0).y(0).w(100).h(100);
+			if (nk_begin(context, "DEBUG", position, NK_WINDOW_NO_INPUT | NK_WINDOW_NO_SCROLLBAR | NK_WINDOW_BACKGROUND)) {
+				nk_layout_row_dynamic(context, 35, 1);
+				nk_label(context, "FPS: " + game.getWindow().getFps(), NK_TEXT_LEFT);
+			}
+			nk_end(context);
+		}
+	}
+
+}

--- a/base/src/main/java/com/avogine/util/FrameProfiler.java
+++ b/base/src/main/java/com/avogine/util/FrameProfiler.java
@@ -1,12 +1,12 @@
 package com.avogine.util;
 
-import java.text.DecimalFormat;
+import java.text.*;
 import java.util.*;
 
 import com.avogine.logging.AvoLog;
 
 /**
- *
+ * Singleton for profiling the game loop.
  */
 public enum FrameProfiler implements Profilable {
 
@@ -110,19 +110,19 @@ public enum FrameProfiler implements Profilable {
 			double budgets = getBudgetAverage();
 			
 			String frameTime = df.format(frames);
-			String framePerBudget = DecimalFormat.getPercentInstance().format(frames / budgets);
+			String framePerBudget = NumberFormat.getPercentInstance().format(frames / budgets);
 
 			String inputTime = df.format(input);
-			String inputPerFrame = DecimalFormat.getPercentInstance().format(input / frames);
-			String inputPerBudget = DecimalFormat.getPercentInstance().format(input / budgets);
+			String inputPerFrame = NumberFormat.getPercentInstance().format(input / frames);
+			String inputPerBudget = NumberFormat.getPercentInstance().format(input / budgets);
 			
 			String updateTime = df.format(update);
-			String updatePerFrame = DecimalFormat.getPercentInstance().format(update / frames);
-			String updatePerBudget = DecimalFormat.getPercentInstance().format(update / budgets);
+			String updatePerFrame = NumberFormat.getPercentInstance().format(update / frames);
+			String updatePerBudget = NumberFormat.getPercentInstance().format(update / budgets);
 			
 			String renderTime = df.format(render);
-			String renderPerFrame = DecimalFormat.getPercentInstance().format(render / frames);
-			String renderPerBudget = DecimalFormat.getPercentInstance().format(render / budgets);
+			String renderPerFrame = NumberFormat.getPercentInstance().format(render / frames);
+			String renderPerBudget = NumberFormat.getPercentInstance().format(render / budgets);
 			
 			AvoLog.log().debug("""
 
@@ -145,62 +145,51 @@ public enum FrameProfiler implements Profilable {
 	},
 	
 	/**
-	 * A No-Op profiler that performs no actions while profiling.
+	 * A No-OP profiler that performs no actions while profiling.
 	 */
 	NO_OP;
-
-	@Override
-	public void startFrame() {}
-
-	@Override
-	public void endFrame() {}
-
-	@Override
-	public void endBudget() {}
-	
-	@Override
-	public void inputStart() {}
-	
-	@Override
-	public void inputEnd() {}
-
-	@Override
-	public void updateStart() {}
-
-	@Override
-	public void updateEnd() {}
-
-	@Override
-	public void renderStart() {}
-
-	@Override
-	public void renderEnd() {}
-
-	@Override
-	public void printAverages() {}
-
 }
 
 sealed interface Profilable permits FrameProfiler {
 	
-	public void startFrame();
+	public default void startFrame() {
+		// Default No-OP
+	}
 	
-	public void endFrame();
+	public default void endFrame() {
+		// Default No-OP
+	}
 	
-	public void endBudget();
+	public default void endBudget() {
+		// Default No-OP
+	}
 	
-	public void inputStart();
+	public default void inputStart() {
+		// Default No-OP
+	}
 	
-	public void inputEnd();
+	public default void inputEnd() {
+		// Default No-OP
+	}
 	
-	public void updateStart();
+	public default void updateStart() {
+		// Default No-OP
+	}
 	
-	public void updateEnd();
+	public default void updateEnd() {
+		// Default No-OP
+	}
 	
-	public void renderStart();
+	public default void renderStart() {
+		// Default No-OP
+	}
 	
-	public void renderEnd();
+	public default void renderEnd() {
+		// Default No-OP
+	}
 	
-	public void printAverages();
+	public default void printAverages() {
+		// Default No-OP
+	}
 	
 }

--- a/base/src/main/java/com/avogine/util/FrameProfiler.java
+++ b/base/src/main/java/com/avogine/util/FrameProfiler.java
@@ -1,0 +1,206 @@
+package com.avogine.util;
+
+import java.text.DecimalFormat;
+import java.util.*;
+
+import com.avogine.logging.AvoLog;
+
+/**
+ *
+ */
+public enum FrameProfiler implements Profilable {
+
+	/**
+	 * Profiler to use when tracking game loop processing times.
+	 */
+	DEBUG {
+		private final List<Long> frameNanos = new ArrayList<>();
+		private final List<Long> inputNanos = new ArrayList<>();
+		private final List<Long> updateNanos = new ArrayList<>();
+		private final List<Long> renderNanos = new ArrayList<>();
+		private final List<Long> budgetNanos = new ArrayList<>();
+
+		private long frameStart;
+		private long inputStart;
+		private long updateStart;
+		private long renderStart;
+		private final DecimalFormat df = new DecimalFormat("###000,000.00μs");
+
+		@Override
+		public void startFrame() {
+			frameStart = System.nanoTime();
+		}
+
+		@Override
+		public void endFrame() {
+			frameNanos.add(System.nanoTime() - frameStart);
+		}
+
+		@Override
+		public void endBudget() {
+			budgetNanos.add(System.nanoTime() - frameStart);
+		}
+		
+		@Override
+		public void inputStart() {
+			inputStart = System.nanoTime();
+		}
+		
+		@Override
+		public void inputEnd() {
+			inputNanos.add(System.nanoTime() - inputStart);
+		}
+
+		@Override
+		public void updateStart() {
+			updateStart = System.nanoTime();
+		}
+
+		@Override
+		public void updateEnd() {
+			updateNanos.add(System.nanoTime() - updateStart);
+		}
+
+		@Override
+		public void renderStart() {
+			renderStart = System.nanoTime();
+		}
+
+		@Override
+		public void renderEnd() {
+			renderNanos.add(System.nanoTime() - renderStart);
+		}
+		
+		private double getFrameAverage() {
+			double avg = frameNanos.stream().mapToLong(Long::valueOf).average().orElseThrow();
+			frameNanos.clear();
+			return avg;
+		}
+		
+		private double getInputAverage() {
+			double avg = inputNanos.stream().mapToLong(Long::valueOf).average().orElseThrow();
+			inputNanos.clear();
+			return avg;
+		}
+		
+		private double getUpdateAverage() {
+			double avg = updateNanos.stream().mapToLong(Long::valueOf).average().orElseThrow();
+			updateNanos.clear();
+			return avg;
+		}
+		
+		private double getRenderAverage() {
+			double avg = renderNanos.stream().mapToLong(Long::valueOf).average().orElseThrow();
+			renderNanos.clear();
+			return avg;
+		}
+		
+		private double getBudgetAverage() {
+			double avg = budgetNanos.stream().mapToLong(Long::valueOf).average().orElseThrow();
+			budgetNanos.clear();
+			return avg;
+		}
+
+		@Override
+		public void printAverages() {
+			double frames = getFrameAverage();
+			double input = getInputAverage();
+			double update = getUpdateAverage();
+			double render = getRenderAverage();
+			double budgets = getBudgetAverage();
+			
+			String frameTime = df.format(frames);
+			String framePerBudget = DecimalFormat.getPercentInstance().format(frames / budgets);
+
+			String inputTime = df.format(input);
+			String inputPerFrame = DecimalFormat.getPercentInstance().format(input / frames);
+			String inputPerBudget = DecimalFormat.getPercentInstance().format(input / budgets);
+			
+			String updateTime = df.format(update);
+			String updatePerFrame = DecimalFormat.getPercentInstance().format(update / frames);
+			String updatePerBudget = DecimalFormat.getPercentInstance().format(update / budgets);
+			
+			String renderTime = df.format(render);
+			String renderPerFrame = DecimalFormat.getPercentInstance().format(render / frames);
+			String renderPerBudget = DecimalFormat.getPercentInstance().format(render / budgets);
+			
+			AvoLog.log().debug("""
+
+					Frame Time: 	{}
+					Input Time: 	{}
+					Update Time:	{}
+					Render Time:	{}
+
+					Input/Frame:	{}
+					Update/Frame:	{}
+					Render/Frame:	{}
+					Frame/Budget:	{}
+					Input/Budget:	{}
+					Update/Budget:	{}
+					Render/Budget:	{}
+					""",
+					frameTime, inputTime, updateTime, renderTime,
+					inputPerFrame, updatePerFrame, renderPerFrame, framePerBudget, inputPerBudget, updatePerBudget, renderPerBudget);
+		}
+	},
+	
+	/**
+	 * A No-Op profiler that performs no actions while profiling.
+	 */
+	NO_OP;
+
+	@Override
+	public void startFrame() {}
+
+	@Override
+	public void endFrame() {}
+
+	@Override
+	public void endBudget() {}
+	
+	@Override
+	public void inputStart() {}
+	
+	@Override
+	public void inputEnd() {}
+
+	@Override
+	public void updateStart() {}
+
+	@Override
+	public void updateEnd() {}
+
+	@Override
+	public void renderStart() {}
+
+	@Override
+	public void renderEnd() {}
+
+	@Override
+	public void printAverages() {}
+
+}
+
+sealed interface Profilable permits FrameProfiler {
+	
+	public void startFrame();
+	
+	public void endFrame();
+	
+	public void endBudget();
+	
+	public void inputStart();
+	
+	public void inputEnd();
+	
+	public void updateStart();
+	
+	public void updateEnd();
+	
+	public void renderStart();
+	
+	public void renderEnd();
+	
+	public void printAverages();
+	
+}

--- a/log/pom.xml
+++ b/log/pom.xml
@@ -11,7 +11,6 @@
   <properties>
   	<slf4j.version>1.7.36</slf4j.version>
   	<log4j.version>2.18.0</log4j.version>
-  	<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   	<project.reporting.sourceEncoding>UTF-8</project.reporting.sourceEncoding>
   </properties>
   

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <plugins>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.8.1</version>
+        <version>3.11.0</version>
       </plugin>
     </plugins>
   </build>


### PR DESCRIPTION
Frame profiling data can now be collected by enabling the DEBUG profiler in Avogine. By default it's set to a NO-OP profiler that doesn't track anything, but DEBUG will log average frame times to the console. Added another UI window for displaying FPS.
Made some slight tweaks to game loop sleeping, should be no functional changes.
POM cleanup, updating compiler plugin.