### PR TITLE
Attempting to authenticate maven to perform releases

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,6 +12,7 @@
   </modules>
   
   <scm>
+	<connection>scm:git:https://github.com/avoduhcado/mavogine.git</connection>
 	<developerConnection>scm:git:https://github.com/avoduhcado/mavogine.git</developerConnection>
   </scm>
   
@@ -30,6 +31,7 @@
     <joml.version>1.10.1</joml.version>
     <lwjgl.natives>natives-windows</lwjgl.natives>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <project.scm.id>github</project.scm.id>
   </properties>
   
   <build>


### PR DESCRIPTION
If this doesn't work it's likely an issue with branch protection in github restricting pushing directly to master and will need configured via github-actions.