### PR TITLE
Update maven-publish.yml

### DIFF
--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -7,9 +7,6 @@ on:
   push:
     branches:
       - 'master'
-    # Version tags should not publish packages, as that should be performed by the maven release plugin
-    tags-ignore:
-      - v*
 
 jobs:
   build:


### PR DESCRIPTION
Removing ignore tags clause, the action was still being triggered regardless because the branch was pushed and not just a tag.