### PR TITLE
Suppressing maven javadoc plugin errors

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,13 +59,22 @@
 					<releaseProfiles>releases</releaseProfiles>
 				</configuration>
 			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-source-plugin</artifactId>
+				<version>3.2.1</version>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-javadoc-plugin</artifactId>
+				<version>3.6.3</version>
+			</plugin>
 		</plugins>
 	</pluginManagement>
 	<plugins>
 		<plugin>
 			<groupId>org.apache.maven.plugins</groupId>
 			<artifactId>maven-source-plugin</artifactId>
-			<version>3.2.1</version>
 			<executions>
 				<execution>
 					<phase>deploy</phase>
@@ -79,7 +88,6 @@
 		<plugin>
 			<groupId>org.apache.maven.plugins</groupId>
 			<artifactId>maven-javadoc-plugin</artifactId>
-			<version>3.6.3</version>
 			<executions>
 				<execution>
 					<phase>deploy</phase>
@@ -89,6 +97,9 @@
 					</goals>
 				</execution>
 			</executions>
+			<configuration>
+				<doclint>none</doclint>
+			</configuration>
 		</plugin>
 	</plugins>
   </build>


### PR DESCRIPTION
Javadoc is more strict post Java8, but this should not prevent builds from working. Should fix actual javadoc later.