### PR TITLE
Removing phase declaration in source and javadoc plugins

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
 				<configuration>
 					<tagNameFormat>v@{project.version}</tagNameFormat>
 					<autoVersionSubmodules>true</autoVersionSubmodules>
-					<scmCommentPrefix>[maven-release-plugin][[skip ci]</scmCommentPrefix>
+					<scmCommentPrefix>[maven-release-plugin][skip ci]</scmCommentPrefix>
 					<releaseProfiles>releases</releaseProfiles>
 				</configuration>
 			</plugin>
@@ -77,7 +77,6 @@
 			<artifactId>maven-source-plugin</artifactId>
 			<executions>
 				<execution>
-					<phase>deploy</phase>
 					<id>attach-sources</id>
 					<goals>
 						<goal>jar-no-fork</goal>
@@ -90,7 +89,6 @@
 			<artifactId>maven-javadoc-plugin</artifactId>
 			<executions>
 				<execution>
-					<phase>deploy</phase>
 					<id>attach-javadocs</id>
 					<goals>
 						<goal>jar</goal>


### PR DESCRIPTION
Unsure what adverse effects this might have, but it generates and attaches source/javadoc as expected.