### PR TITLE
Updating maven plugins and project dependencies

### DIFF
--- a/base/.classpath
+++ b/base/.classpath
@@ -43,8 +43,8 @@
 	</classpathentry>
 	<classpathentry kind="src" output="target/test-classes" path="target/generated-test-sources/test-annotations">
 		<attributes>
-			<attribute name="test" value="true"/>
 			<attribute name="optional" value="true"/>
+			<attribute name="test" value="true"/>
 		</attributes>
 	</classpathentry>
 	<classpathentry kind="output" path="target/classes"/>

--- a/base/pom.xml
+++ b/base/pom.xml
@@ -97,7 +97,7 @@
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
-			<version>2.14.0-rc1</version>
+			<version>2.20.0</version>
 		</dependency>
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>

--- a/base/src/main/java/com/avogine/audio/Audio.java
+++ b/base/src/main/java/com/avogine/audio/Audio.java
@@ -288,7 +288,7 @@ public class Audio {
 				default -> AvoLog.log().debug("Event of type: {}", eventType);
 			}
 		});
-		SOFTEvents.alEventCallbackSOFT(callback, (ByteBuffer) null);
+		SOFTEvents.alEventCallbackSOFT(callback, MemoryUtil.NULL);
 		int[] eventTypes = new int[] { SOFTEvents.AL_EVENT_TYPE_DISCONNECTED_SOFT };
 		SOFTEvents.alEventControlSOFT(eventTypes, true);
 		softEventCallbacks.add(callback);

--- a/log/.classpath
+++ b/log/.classpath
@@ -43,8 +43,8 @@
 	</classpathentry>
 	<classpathentry kind="src" output="target/test-classes" path="target/generated-test-sources/test-annotations">
 		<attributes>
-			<attribute name="test" value="true"/>
 			<attribute name="optional" value="true"/>
+			<attribute name="test" value="true"/>
 		</attributes>
 	</classpathentry>
 	<classpathentry kind="output" path="target/classes"/>

--- a/log/pom.xml
+++ b/log/pom.xml
@@ -9,31 +9,15 @@
   <artifactId>log</artifactId>
   
   <properties>
-  	<slf4j.version>1.7.36</slf4j.version>
-  	<log4j.version>2.18.0</log4j.version>
+  	<slf4j.version>2.0.17</slf4j.version>
   	<project.reporting.sourceEncoding>UTF-8</project.reporting.sourceEncoding>
   </properties>
   
 	<dependencies>
 		<dependency>
-		    <groupId>org.slf4j</groupId>
-		    <artifactId>slf4j-api</artifactId>
-		    <version>${slf4j.version}</version>
-		</dependency>
-		<dependency>
-		    <groupId>org.apache.logging.log4j</groupId>
-		    <artifactId>log4j-api</artifactId>
-		    <version>${log4j.version}</version>
-		</dependency>
-		<dependency>
-		    <groupId>org.apache.logging.log4j</groupId>
-		    <artifactId>log4j-core</artifactId>
-		    <version>${log4j.version}</version>
-		</dependency>
-		<dependency>
-		    <groupId>org.apache.logging.log4j</groupId>
-		    <artifactId>log4j-slf4j-impl</artifactId>
-		    <version>${log4j.version}</version>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-api</artifactId>
+			<version>${slf4j.version}</version>
 		</dependency>
 	</dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
   <properties>
     <maven.compiler.release>21</maven.compiler.release>
     <mavogine.version>0.1.3-SNAPSHOT</mavogine.version>
-    <lwjgl.version>3.3.3</lwjgl.version>
+    <lwjgl.version>3.3.6</lwjgl.version>
     <joml.version>1.10.8</joml.version>
     <lwjgl.natives>natives-windows</lwjgl.natives>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -36,57 +36,41 @@
   </properties>
   
   <build>
-	<pluginManagement>
-		<plugins>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.13.0</version>
-			</plugin>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-deploy-plugin</artifactId>
-				<version>3.1.2</version>
-			</plugin>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-release-plugin</artifactId>
-				<version>3.0.1</version>
-				<configuration>
-					<tagNameFormat>v@{project.version}</tagNameFormat>
-					<autoVersionSubmodules>true</autoVersionSubmodules>
-					<scmCommentPrefix>[maven-release-plugin][skip ci]</scmCommentPrefix>
-					<releaseProfiles>releases</releaseProfiles>
-				</configuration>
-			</plugin>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-source-plugin</artifactId>
-				<version>3.2.1</version>
-			</plugin>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>3.6.3</version>
-			</plugin>
-		</plugins>
-	</pluginManagement>
 	<plugins>
 		<plugin>
 			<groupId>org.apache.maven.plugins</groupId>
-			<artifactId>maven-source-plugin</artifactId>
+			<artifactId>maven-compiler-plugin</artifactId>
+			<version>3.14.0</version>
+		</plugin>
+		<plugin>
+			<groupId>org.apache.maven.plugins</groupId>
+			<artifactId>maven-enforcer-plugin</artifactId>
+			<version>3.6.1</version>
 			<executions>
 				<execution>
-					<id>attach-sources</id>
+					<id>enforce-maven</id>
 					<goals>
-						<goal>jar-no-fork</goal>
+						<goal>enforce</goal>
 					</goals>
+					<configuration>
+						<rules>
+							<requireMavenVersion>
+								<version>3.6.3</version>
+							</requireMavenVersion>
+						</rules>
+					</configuration>
 				</execution>
 			</executions>
 		</plugin>
 		<plugin>
 			<groupId>org.apache.maven.plugins</groupId>
+			<artifactId>maven-deploy-plugin</artifactId>
+			<version>3.1.4</version>
+		</plugin>
+		<plugin>
+			<groupId>org.apache.maven.plugins</groupId>
 			<artifactId>maven-javadoc-plugin</artifactId>
+			<version>3.11.3</version>
 			<executions>
 				<execution>
 					<id>attach-javadocs</id>
@@ -98,6 +82,30 @@
 			<configuration>
 				<doclint>none</doclint>
 			</configuration>
+		</plugin>
+		<plugin>
+			<groupId>org.apache.maven.plugins</groupId>
+			<artifactId>maven-release-plugin</artifactId>
+			<version>3.1.1</version>
+			<configuration>
+				<tagNameFormat>v@{project.version}</tagNameFormat>
+				<autoVersionSubmodules>true</autoVersionSubmodules>
+				<scmCommentPrefix>[maven-release-plugin][skip ci]</scmCommentPrefix>
+				<releaseProfiles>releases</releaseProfiles>
+			</configuration>
+		</plugin>
+		<plugin>
+			<groupId>org.apache.maven.plugins</groupId>
+			<artifactId>maven-source-plugin</artifactId>
+			<version>3.3.1</version>
+			<executions>
+				<execution>
+					<id>attach-sources</id>
+					<goals>
+						<goal>jar-no-fork</goal>
+					</goals>
+				</execution>
+			</executions>
 		</plugin>
 	</plugins>
   </build>
@@ -124,7 +132,7 @@
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>
 			<artifactId>junit-jupiter</artifactId>
-			<version>5.8.2</version>
+			<version>5.13.4</version>
 			<type>pom.sha512</type>
 			<scope>test</scope>
 		</dependency>


### PR DESCRIPTION
Added maven-enforcer-plugin and declared minimum maven version for build.
Applied plugin and dependency updates specified from mvn version. Updated from RC dependencies where applicable to stable releases. Fixed compiler error from OpenAL dependency update. Moved Log4j dependency out of log module, it's now the responsibility of library users to declare a logging framework.
Retained log4j properties resource for default usage.

closes #58 