### PR TITLE
Refactoring Texture building

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,9 +30,3 @@ hs_err_pid*
 .factorypath
 .classpath
 .project
-
-# Project modules
-/base/
-/concurrent/
-/ecs/
-/log/

--- a/base/pom.xml
+++ b/base/pom.xml
@@ -7,6 +7,18 @@
 	</parent>
 	<artifactId>base</artifactId>
 	
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<configuration>
+					<enablePreview>true</enablePreview>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+	
 	<dependencies>
 		<dependency>
 			<groupId>org.lwjgl</groupId>

--- a/base/src/main/java/com/avogine/io/Window.java
+++ b/base/src/main/java/com/avogine/io/Window.java
@@ -106,7 +106,7 @@ public class Window {
 			throw new IllegalStateException("Failed to create window!");
 		}
 		
-		GLFW.glfwSetFramebufferSizeCallback(id, (window, w, h) -> resized(w, h));
+		GLFW.glfwSetFramebufferSizeCallback(id, (_, w, h) -> resized(w, h));
 		
 		try (MemoryStack stack = MemoryStack.stackPush()) {
 			IntBuffer pWidth = stack.mallocInt(1);
@@ -124,7 +124,7 @@ public class Window {
 		}
 		
 		targetFps = maxFps;
-		GLFW.glfwSetWindowFocusCallback(id, (windowC, focused) -> targetFps = focused ? maxFps : maxBackgroundFps);
+		GLFW.glfwSetWindowFocusCallback(id, (_, focused) -> targetFps = focused ? maxFps : maxBackgroundFps);
 		
 		// XXX Customize by WindowConfig?
 		if (GLFW.glfwGetWindowAttrib(id, GLFW.GLFW_TRANSPARENT_FRAMEBUFFER) == GLFW.GLFW_TRUE) {

--- a/base/src/main/java/com/avogine/render/Render.java
+++ b/base/src/main/java/com/avogine/render/Render.java
@@ -1,0 +1,43 @@
+package com.avogine.render;
+
+/**
+ *
+ */
+public abstract class Render {
+
+	private static float anisotropicFiltering = 4f;
+
+	private Render() {
+	}
+
+	/**
+	 * @return the anisotropicFiltering
+	 */
+	public static float getAnisotropicFiltering() {
+		return anisotropicFiltering;
+	}
+
+	/**
+	 * @param anisotropicFiltering the anisotropicFiltering to set
+	 */
+	public static void setAnisotropicFiltering(float anisotropicFiltering) {
+		Render.anisotropicFiltering = anisotropicFiltering;
+	}
+
+	/**
+	 *
+	 * @param anisotropicFiltering
+	 */
+	public record RenderPreferences(float anisotropicFiltering) {
+		 
+		public static RenderPreferences defaultPreferences = new RenderPreferences(4f);
+		
+		/**
+		 * TODO Attempt to load saved prefs and fallback to default if no saved prefs are found
+		 * @return the user's saved {@link RenderPreferences} or the default configuration if no saved preferences exist.
+		 */
+		public static RenderPreferences loadPrefs() {
+			return defaultPreferences;
+		}
+	}
+}

--- a/base/src/main/java/com/avogine/render/SceneRender.java
+++ b/base/src/main/java/com/avogine/render/SceneRender.java
@@ -9,13 +9,13 @@ import com.avogine.io.Window;
  * @param <T> The {@link Scene} implementation this renderer should be capable of drawing.
  *
  */
-public interface SceneRender<T extends Scene> {
-
+public abstract class SceneRender<T extends Scene> {
+	
 	/**
 	 * Initialize render specific state.
 	 * @param window 
 	 */
-	public default void init(Window window) {
+	public void init(Window window) {
 		// Set a nice Avocado green default color
 		glClearColor(177f / 255f, 193f / 255f, 71f / 255f, 1.0f);
 	}
@@ -24,11 +24,11 @@ public interface SceneRender<T extends Scene> {
 	 * @param window
 	 * @param scene
 	 */
-	public void render(Window window, T scene);
+	public abstract void render(Window window, T scene);
 	
 	/**
 	 * 
 	 */
-	public void cleanup();
+	public abstract void cleanup();
 	
 }

--- a/base/src/main/java/com/avogine/render/opengl/font/Font.java
+++ b/base/src/main/java/com/avogine/render/opengl/font/Font.java
@@ -1,5 +1,6 @@
 package com.avogine.render.opengl.font;
 
+import static org.lwjgl.opengl.GL11C.GL_RED;
 import static org.lwjgl.stb.STBTruetype.*;
 
 import java.awt.Point;
@@ -229,10 +230,11 @@ public class Font {
 			stbtt_PackEnd(packContext);
 
 			try {
-				return Texture.gen2D(fontMapTex -> fontMapTex
-						.filter().linear()
-						.wrap2D().repeat()
-						.image2D(BITMAP_WIDTH, BITMAP_HEIGHT, bitmap));
+				return Texture.gen2D(tex -> tex
+						.minFilter().linear()
+						.magFilter().linear()
+						.wrapST().repeat()
+						.image2D(BITMAP_WIDTH, BITMAP_HEIGHT, GL_RED, bitmap));
 			} finally {
 				MemoryUtil.memFree(bitmap);
 			}

--- a/base/src/main/java/com/avogine/render/opengl/texture/Texture.java
+++ b/base/src/main/java/com/avogine/render/opengl/texture/Texture.java
@@ -33,6 +33,7 @@ import java.util.function.*;
 import org.lwjgl.opengl.*;
 import org.lwjgl.system.MemoryUtil;
 
+import com.avogine.render.Render;
 import com.avogine.render.opengl.texture.Texture.Builder.TexImage;
 import com.avogine.render.opengl.texture.Texture.Texture2DBuilder.TexImage2D;
 import com.avogine.render.opengl.texture.Texture.TextureCubeMapBuilder.TexImageCubeMap;
@@ -41,7 +42,7 @@ import com.avogine.render.opengl.texture.Texture.TextureCubeMapBuilder.TexImageC
  *
  */
 public record Texture(int id, int target) {
-
+	
 	public Texture(int target) {
 		this(glGenTextures(), target);
 	}
@@ -69,7 +70,9 @@ public record Texture(int id, int target) {
 					glTexImage2D(GL_TEXTURE_CUBE_MAP_POSITIVE_X + i, level, internalFormat, width, height, border, format, type, pixels[i]);
 				}
 			}
-			case null -> {}
+			case null -> {
+				// No image to load
+			}
 		}
 		if (generateMipmap) {
 			glGenerateMipmap(target);
@@ -105,7 +108,7 @@ public record Texture(int id, int target) {
 		glBindTexture(target, 0);
 	}
 	
-	public static abstract class Builder<SELF extends Builder<SELF>> {
+	public abstract static class Builder<SELF extends Builder<SELF>> {
 		protected final int target;
 		private final Set<Parameter> params;
 		protected TexImage texImage;
@@ -323,8 +326,7 @@ public record Texture(int id, int target) {
 		}
 		
 		public SELF anisotropicFiltering() {
-			// TODO#40: Extract some global Anisotropic filtering value
-			return anisotropicFiltering(4f);
+			return anisotropicFiltering(Render.getAnisotropicFiltering());
 		}
 	}
 	

--- a/base/src/main/java/com/avogine/render/opengl/texture/Texture.java
+++ b/base/src/main/java/com/avogine/render/opengl/texture/Texture.java
@@ -39,14 +39,24 @@ import com.avogine.render.opengl.texture.Texture.Texture2DBuilder.TexImage2D;
 import com.avogine.render.opengl.texture.Texture.TextureCubeMapBuilder.TexImageCubeMap;
 
 /**
- *
+ * @param id the texture object name.
+ * @param target the texture target.
  */
 public record Texture(int id, int target) {
 	
+	/**
+	 * @param target the texture target.
+	 */
 	public Texture(int target) {
 		this(glGenTextures(), target);
 	}
 	
+	/**
+	 * @param target the texture target.
+	 * @param params a set of texture parameters to apply.
+	 * @param image the {@link TexImage} this texture contains.
+	 * @param generateMipmap whether to generate mip-map images for this texture.
+	 */
 	public Texture(int target, Set<Builder.Parameter> params, TexImage image, boolean generateMipmap) {
 		this(target);
 		bind();
@@ -80,10 +90,18 @@ public record Texture(int id, int target) {
 		unbind();
 	}
 	
+	/**
+	 * @param builder
+	 * @return a new {@link Texture} set to the {@link GL11C#GL_TEXTURE_2D} target.
+	 */
 	public static Texture gen2D(UnaryOperator<Texture2DBuilder> builder) {
 		return builder.andThen(Builder::build).apply(new Texture2DBuilder());
 	}
 
+	/**
+	 * @param builder
+	 * @return a new {@link Texture} set to the {@link GL13C#GL_TEXTURE_CUBE_MAP} target.
+	 */
 	public static Texture genCubeMap(UnaryOperator<TextureCubeMapBuilder> builder) {
 		return builder.andThen(Builder::build).apply(new TextureCubeMapBuilder());
 	}
@@ -95,19 +113,34 @@ public record Texture(int id, int target) {
 		glDeleteTextures(id);
 	}
 	
+	/**
+	 * Activate the specified texture unit and bind this texture.
+	 * @param textureSlot
+	 */
 	public void activate(int textureSlot) {
 		glActiveTexture(GL_TEXTURE0 + textureSlot);
 		bind();
 	}
 	
+	/**
+	 * Bind this texture to its target.
+	 */
 	public void bind() {
 		glBindTexture(target, id);
 	}
 	
+	/**
+	 * Un-bind this texture target.
+	 */
 	public void unbind() {
 		glBindTexture(target, 0);
 	}
 	
+	/**
+	 * Abstract builder for building {@link Texture}s.
+	 * @param <SELF>
+	 */
+	@SuppressWarnings("java:S119")
 	public abstract static class Builder<SELF extends Builder<SELF>> {
 		protected final int target;
 		private final Set<Parameter> params;
@@ -126,26 +159,57 @@ public record Texture(int id, int target) {
 		}
 		
 		public sealed interface TexImage {
+			/**
+			 * @return the level-of-detail number
+			 */
 			public int level();
 			
+			/**
+			 * @return the texture internal format
+			 */
 			public int internalFormat();
 			
+			/**
+			 * @return the texture width
+			 */
 			public int width();
 			
+			/**
+			 * @return the texture height
+			 */
 			public int height();
 			
+			/**
+			 * @return the texture border width
+			 */
 			public int border();
 			
+			/**
+			 * @return the texel data format
+			 */
 			public int format();
 			
+			/**
+			 * @return the texel data type
+			 */
 			public int type();
 		}
 		
+		/**
+		 * @param pname
+		 * @param param
+		 * @return this
+		 */
 		public SELF parameteri(int pname, int param) {
 			params.add(new Parameteri(pname, param));
 			return self();
 		}
 		
+		/**
+		 * @param pname
+		 * @param param
+		 * @return this
+		 */
 		public SELF parameterf(int pname, float param) {
 			params.add(new Parameterf(pname, param));
 			return self();
@@ -153,6 +217,11 @@ public record Texture(int id, int target) {
 		
 		public sealed interface Parameter {}
 		
+		/**
+		 *
+		 * @param pname
+		 * @param param
+		 */
 		public record Parameteri(int pname, int param) implements Parameter {
 			@Override
 			public int hashCode() {
@@ -170,6 +239,11 @@ public record Texture(int id, int target) {
 			}
 		}
 		
+		/**
+		 *
+		 * @param pname
+		 * @param param
+		 */
 		public record Parameterf(int pname, float param) implements Parameter {
 			@Override
 			public int hashCode() {
@@ -187,49 +261,83 @@ public record Texture(int id, int target) {
 			}
 		}
 		
+		/**
+		 * @return {@link MinFilter}
+		 */
 		public MinFilter minFilter() {
 			return new MinFilter();
 		}
 		
+		/**
+		 * @return {@link MagFilter}
+		 */
 		public MagFilter magFilter() {
 			return new MagFilter();
 		}
 		
 		public abstract sealed class FilterParam {
+			/**
+			 * @param function
+			 * @return {@link Builder}
+			 */
 			public abstract SELF function(int function);
 			
+			/**
+			 * @return {@link Builder}
+			 */
 			public SELF nearest() {
 				return function(GL_NEAREST);
 			}
 			
+			/**
+			 * @return {@link Builder}
+			 */
 			public SELF linear() {
 				return function(GL_LINEAR);
 			}
 		}
 		
+		/**
+		 *
+		 */
 		public final class MinFilter extends FilterParam {
 			@Override
 			public SELF function(int function) {
 				return Builder.this.parameteri(GL_TEXTURE_MIN_FILTER, function);
 			}
 			
+			/**
+			 * @return {@link Builder}
+			 */
 			public SELF nearestMipmapNearest() {
 				return function(GL_NEAREST_MIPMAP_NEAREST);
 			}
 
+			/**
+			 * @return {@link Builder}
+			 */
 			public SELF linearMipmapNearest() {
 				return function(GL_LINEAR_MIPMAP_NEAREST);
 			}
 
+			/**
+			 * @return {@link Builder}
+			 */
 			public SELF nearestMipmapLinear() {
 				return function(GL_NEAREST_MIPMAP_LINEAR);
 			}
 
+			/**
+			 * @return {@link Builder}
+			 */
 			public SELF linearMipmapLinear() {
 				return function(GL_LINEAR_MIPMAP_LINEAR);
 			}
 		}
 		
+		/**
+		 *
+		 */
 		public final class MagFilter extends FilterParam {
 			@Override
 			public SELF function(int function) {
@@ -237,22 +345,37 @@ public record Texture(int id, int target) {
 			}
 		}
 		
+		/**
+		 * @return {@link WrapS}
+		 */
 		public WrapS wrapS() {
 			return new WrapS();
 		}
 		
+		/**
+		 * @return {@link WrapT}
+		 */
 		public WrapT wrapT() {
 			return new WrapT();
 		}
 		
+		/**
+		 * @return {@link WrapR}
+		 */
 		public WrapR wrapR() {
 			return new WrapR();
 		}
 		
+		/**
+		 * @return {@link WrapST}
+		 */
 		public WrapST wrapST() {
 			return new WrapST();
 		}
 		
+		/**
+		 * @return {@link WrapSTR}
+		 */
 		public WrapSTR wrapSTR() {
 			return new WrapSTR();
 		}
@@ -260,18 +383,30 @@ public record Texture(int id, int target) {
 		public abstract sealed class WrapParam {
 			protected abstract SELF set(int param);
 			
+			/**
+			 * @return {@link Builder}
+			 */
 			public SELF clampToEdge() {
 				return set(GL_CLAMP_TO_EDGE);
 			}
 			
+			/**
+			 * @return {@link Builder}
+			 */
 			public SELF clampToBorder() {
 				return set(GL_CLAMP_TO_BORDER);
 			}
 			
+			/**
+			 * @return {@link Builder}
+			 */
 			public SELF mirroredRepeat() {
 				return set(GL_MIRRORED_REPEAT);
 			}
 			
+			/**
+			 * @return {@link Builder}
+			 */
 			public SELF repeat() {
 				return set(GL_REPEAT);
 			}
@@ -284,6 +419,9 @@ public record Texture(int id, int target) {
 			}
 		}
 		
+		/**
+		 *
+		 */
 		public final class WrapT extends WrapParam {
 			@Override
 			protected SELF set(int param) {
@@ -291,6 +429,9 @@ public record Texture(int id, int target) {
 			}
 		}
 		
+		/**
+		 *
+		 */
 		public final class WrapR extends WrapParam {
 			@Override
 			protected SELF set(int param) {
@@ -305,6 +446,9 @@ public record Texture(int id, int target) {
 			}
 		}
 		
+		/**
+		 *
+		 */
 		public final class WrapSTR extends WrapST {
 			@Override
 			protected SELF set(int param) {
@@ -312,11 +456,18 @@ public record Texture(int id, int target) {
 			}
 		}
 		
+		/**
+		 * @return {@link Builder}
+		 */
 		public SELF generateMipmap() {
 			generateMipmap = true;
 			return self();
 		}
 		
+		/**
+		 * @param amount
+		 * @return {@link Builder}
+		 */
 		public SELF anisotropicFiltering(float amount) {
 			if (GL.getCapabilities().GL_EXT_texture_filter_anisotropic) {
 				amount = Math.min(amount, glGetFloat(EXTTextureFilterAnisotropic.GL_MAX_TEXTURE_MAX_ANISOTROPY_EXT));
@@ -325,11 +476,17 @@ public record Texture(int id, int target) {
 			return self();
 		}
 		
+		/**
+		 * @return {@link Builder}
+		 */
 		public SELF anisotropicFiltering() {
 			return anisotropicFiltering(Render.getAnisotropicFiltering());
 		}
 	}
 	
+	/**
+	 *
+	 */
 	public static final class Texture2DBuilder extends Builder<Texture2DBuilder> {
 		protected Texture2DBuilder() {
 			super(GL_TEXTURE_2D);
@@ -340,32 +497,84 @@ public record Texture(int id, int target) {
 			return this;
 		}
 
+		/**
+		 * @param builder
+		 * @return {@link Texture2DBuilder}
+		 */
 		public Texture2DBuilder image2D(Consumer<Texture2DBuilder> builder) {
 			builder.accept(this);
 			return self();
 		}
 		
+		/**
+		 * @param <T>
+		 * @param level
+		 * @param internalFormat
+		 * @param width
+		 * @param height
+		 * @param format
+		 * @param type
+		 * @param pixels
+		 * @return {@link Texture2DBuilder}
+		 */
 		public <T extends Buffer> Texture2DBuilder image2D(int level, int internalFormat, int width, int height, int format, int type, T pixels) {
 			this.texImage = new TexImage2D<>(level, internalFormat, width, height, 0, format, type, pixels);
 			return self();
 		}
 		
+		/**
+		 * @param level
+		 * @param internalFormat
+		 * @param width
+		 * @param height
+		 * @param format
+		 * @param pixels
+		 * @return {@link Texture2DBuilder}
+		 */
 		public Texture2DBuilder image2D(int level, int internalFormat, int width, int height, int format, ByteBuffer pixels) {
 			this.texImage = new TexImage2D<>(level, internalFormat, width, height, 0, format, GL_UNSIGNED_BYTE, pixels);
 			return self();
 		}
 		
+		/**
+		 * @param width
+		 * @param height
+		 * @param format
+		 * @param pixels
+		 * @return {@link Texture2DBuilder}
+		 */
 		public Texture2DBuilder image2D(int width, int height, int format, ByteBuffer pixels) {
 			return image2D(0, format, width, height, format, pixels);
 		}
 		
+		/**
+		 * @param width
+		 * @param height
+		 * @param format
+		 * @return {@link Texture2DBuilder}
+		 */
 		public Texture2DBuilder image2D(int width, int height, int format) {
 			return image2D(width, height, format, (ByteBuffer) null);
 		}
 		
+		/**
+		 *
+		 * @param <T>
+		 * @param level
+		 * @param internalFormat
+		 * @param width
+		 * @param height
+		 * @param border
+		 * @param format
+		 * @param type
+		 * @param pixels
+		 */
 		public record TexImage2D<T extends Buffer>(int level, int internalFormat, int width, int height, int border, int format, int type, T pixels) implements TexImage {}
 	}
 	
+	/**
+	 *
+	 */
 	public static final class TextureCubeMapBuilder extends Builder<TextureCubeMapBuilder> {
 		protected TextureCubeMapBuilder() {
 			super(GL_TEXTURE_CUBE_MAP);
@@ -376,30 +585,103 @@ public record Texture(int id, int target) {
 			return this;
 		}
 		
+		/**
+		 * @param builder
+		 * @return {@link TextureCubeMapBuilder}
+		 */
 		public TextureCubeMapBuilder cubeMap(Consumer<TextureCubeMapBuilder> builder) {
 			builder.accept(this);
 			return self();
 		}
 		
+		/**
+		 * 
+		 * @param width
+		 * @param height
+		 * @param format
+		 * @param positiveX
+		 * @param negativeX
+		 * @param positiveY
+		 * @param negativeY
+		 * @param positiveZ
+		 * @param negativeZ
+		 * @return {@link TextureCubeMapBuilder}
+		 */
+		@SuppressWarnings("java:S107") // Cube maps require exactly 6 faces, specifying them as individual parameters avoids missing faces.
 		public TextureCubeMapBuilder cubeMap(int width, int height, int format,
 				ByteBuffer positiveX, ByteBuffer negativeX, ByteBuffer positiveY, ByteBuffer negativeY, ByteBuffer positiveZ, ByteBuffer negativeZ) {
 			this.texImage = new TexImageCubeMap(0, format, width, height, 0, format, GL_UNSIGNED_BYTE, new ByteBuffer[] { positiveX, negativeX, positiveY, negativeY, positiveZ, negativeZ });
 			return self();
 		}
 		
+		/**
+		 * @param width
+		 * @param height
+		 * @param format
+		 * @param allFaces
+		 * @return {@link TextureCubeMapBuilder}
+		 */
 		public TextureCubeMapBuilder cubeMap(int width, int height, int format, ByteBuffer allFaces) {
 			return cubeMap(width, height, format, allFaces, allFaces, allFaces, allFaces, allFaces, allFaces);
 		}
 
+		/**
+		 * @param width
+		 * @param height
+		 * @param format
+		 * @return {@link TextureCubeMapBuilder}
+		 */
 		public TextureCubeMapBuilder cubeMap(int width, int height, int format) {
 			return cubeMap(width, height, format, (ByteBuffer) null);
 		}
 		
+		/**
+		 *
+		 * @param level
+		 * @param internalFormat
+		 * @param width
+		 * @param height
+		 * @param border
+		 * @param format
+		 * @param type
+		 * @param pixels
+		 */
 		public record TexImageCubeMap(int level, int internalFormat, int width, int height, int border, int format, int type, ByteBuffer[] pixels) implements TexImage {
+			/**
+			 * 
+			 */
 			public TexImageCubeMap {
 				if (Objects.requireNonNull(pixels).length != 6) {
 					throw new IllegalArgumentException("CubeMap must specify 6 image buffers.");
 				}
+			}
+
+			@Override
+			public int hashCode() {
+				final int prime = 31;
+				int result = 1;
+				result = prime * result + Arrays.hashCode(pixels);
+				result = prime * result + Objects.hash(border, format, height, internalFormat, level, type, width);
+				return result;
+			}
+
+			@Override
+			public boolean equals(Object obj) {
+				if (this == obj)
+					return true;
+				if (!(obj instanceof TexImageCubeMap))
+					return false;
+				TexImageCubeMap other = (TexImageCubeMap) obj;
+				return border == other.border && format == other.format && height == other.height
+						&& internalFormat == other.internalFormat && level == other.level
+						&& Arrays.equals(pixels, other.pixels) && type == other.type && width == other.width;
+			}
+
+			@Override
+			public String toString() {
+				return "TexImageCubeMap [level=" + level + ", internalFormat=" + internalFormat + ", width=" + width
+						+ ", height=" + height + ", border=" + border + ", format=" + format + ", type=" + type
+						+ ", pixels=" + pixels + "]";
 			}
 		}
 	}

--- a/base/src/main/java/com/avogine/render/opengl/texture/Texture.java
+++ b/base/src/main/java/com/avogine/render/opengl/texture/Texture.java
@@ -1,9 +1,30 @@
 package com.avogine.render.opengl.texture;
 
-import static org.lwjgl.opengl.GL11.*;
-import static org.lwjgl.opengl.GL12.*;
-import static org.lwjgl.opengl.GL13.*;
-import static org.lwjgl.opengl.GL30.glGenerateMipmap;
+import static org.lwjgl.opengl.GL11.glDeleteTextures;
+import static org.lwjgl.opengl.GL11.glGetFloat;
+import static org.lwjgl.opengl.GL11C.GL_LINEAR;
+import static org.lwjgl.opengl.GL11C.GL_LINEAR_MIPMAP_LINEAR;
+import static org.lwjgl.opengl.GL11C.GL_LINEAR_MIPMAP_NEAREST;
+import static org.lwjgl.opengl.GL11C.GL_NEAREST;
+import static org.lwjgl.opengl.GL11C.GL_NEAREST_MIPMAP_LINEAR;
+import static org.lwjgl.opengl.GL11C.GL_NEAREST_MIPMAP_NEAREST;
+import static org.lwjgl.opengl.GL11C.GL_REPEAT;
+import static org.lwjgl.opengl.GL11C.GL_TEXTURE_2D;
+import static org.lwjgl.opengl.GL11C.GL_TEXTURE_MAG_FILTER;
+import static org.lwjgl.opengl.GL11C.GL_TEXTURE_MIN_FILTER;
+import static org.lwjgl.opengl.GL11C.GL_TEXTURE_WRAP_S;
+import static org.lwjgl.opengl.GL11C.GL_TEXTURE_WRAP_T;
+import static org.lwjgl.opengl.GL11C.GL_UNSIGNED_BYTE;
+import static org.lwjgl.opengl.GL11C.glBindTexture;
+import static org.lwjgl.opengl.GL11C.glGenTextures;
+import static org.lwjgl.opengl.GL11C.glTexImage2D;
+import static org.lwjgl.opengl.GL11C.glTexParameterf;
+import static org.lwjgl.opengl.GL11C.glTexParameteri;
+import static org.lwjgl.opengl.GL12C.*;
+import static org.lwjgl.opengl.GL13.GL_TEXTURE0;
+import static org.lwjgl.opengl.GL13C.*;
+import static org.lwjgl.opengl.GL14C.GL_MIRRORED_REPEAT;
+import static org.lwjgl.opengl.GL30C.glGenerateMipmap;
 
 import java.nio.*;
 import java.util.*;
@@ -12,72 +33,58 @@ import java.util.function.*;
 import org.lwjgl.opengl.*;
 import org.lwjgl.system.MemoryUtil;
 
-import com.avogine.logging.AvoLog;
-import com.avogine.render.image.data.ImageData;
-import com.avogine.render.opengl.texture.Texture.TextureBuilder.*;
+import com.avogine.render.opengl.texture.Texture.Builder.TexImage;
+import com.avogine.render.opengl.texture.Texture.Texture2DBuilder.TexImage2D;
+import com.avogine.render.opengl.texture.Texture.TextureCubeMapBuilder.TexImageCubeMap;
 
 /**
- * @param id 
- * @param target 
+ *
  */
 public record Texture(int id, int target) {
+
+	public Texture(int target) {
+		this(glGenTextures(), target);
+	}
 	
-	private Texture(TextureBuilder<?> builder) {
-		this(glGenTextures(), builder.target);
-		
+	public Texture(int target, Set<Builder.Parameter> params, TexImage image, boolean generateMipmap) {
+		this(target);
 		bind();
-		
-		builder.parameters.forEach(this::tex);
-		tex(builder.image2D);
-		
-		if (builder.generateMipmap) {
+		params.forEach(parameter -> {
+			switch (parameter) {
+				case Builder.Parameteri (int pname, int param) -> glTexParameteri(target, pname, param);
+				case Builder.Parameterf (int pname, float param) -> glTexParameterf(target, pname, param);
+			}
+		});
+		switch (image) {
+			case TexImage2D (int level, int internalFormat, int width, int height, int border, int format, int type, var pixels) -> {
+				switch (pixels) {
+					case ByteBuffer pixelBytes -> glTexImage2D(target, level, internalFormat, width, height, border, format, type, pixelBytes);
+					case IntBuffer pixelInts -> glTexImage2D(target, level, internalFormat, width, height, border, format, type, pixelInts);
+					case null -> glTexImage2D(target, level, internalFormat, width, height, border, format, type, MemoryUtil.NULL);
+					default -> throw new IllegalArgumentException("Unsupported pixel buffer value: " + pixels);
+				}
+			}
+			case TexImageCubeMap (int level, int internalFormat, int width, int height, int border, int format, int type, ByteBuffer[] pixels) -> {
+				for (int i = 0; i < 6; i++) {
+					glTexImage2D(GL_TEXTURE_CUBE_MAP_POSITIVE_X + i, level, internalFormat, width, height, border, format, type, pixels[i]);
+				}
+			}
+			case null -> {}
+		}
+		if (generateMipmap) {
 			glGenerateMipmap(target);
 		}
-		
-		unbind(target);
+		unbind();
 	}
 	
-	/**
-	 * @param textureInit
-	 * @return a newly constructed 2D {@link Texture} with the configurations from {@code textureInit} applied.
-	 */
-	public static Texture gen2D(UnaryOperator<Texture2DBuilder> textureInit) {
-		return textureInit
-				.andThen(TextureBuilder.TO_TEXTURE)
-				.apply(new Texture2DBuilder());
+	public static Texture gen2D(UnaryOperator<Texture2DBuilder> builder) {
+		return builder.andThen(Builder::build).apply(new Texture2DBuilder());
 	}
-	
-	/**
-	 * @param textureInit
-	 * @return a newly constructed cube map {@link Texture} with the configurations from {@code textureInit} applied.
-	 */
-	public static Texture genCubeMap(UnaryOperator<TextureCubeMapBuilder> textureInit) {
-		return textureInit
-				.andThen(TextureBuilder.TO_TEXTURE)
-				.apply(new TextureCubeMapBuilder());
+
+	public static Texture genCubeMap(UnaryOperator<TextureCubeMapBuilder> builder) {
+		return builder.andThen(Builder::build).apply(new TextureCubeMapBuilder());
 	}
-	
-	/**
-	 * @param target
-	 */
-	public static void unbind(int target) {
-		glBindTexture(target, 0);
-	}
-	
-	/**
-	 * Clear the currently bound 2D texture.
-	 */
-	public static void unbind2D() {
-		unbind(GL_TEXTURE_2D);
-	}
-	
-	/**
-	 * Clear the currently bound cube map texture.
-	 */
-	public static void unbindCubeMap() {
-		unbind(GL_TEXTURE_CUBE_MAP);
-	}
-	
+
 	/**
 	 * Delete this texture object.
 	 */
@@ -85,544 +92,312 @@ public record Texture(int id, int target) {
 		glDeleteTextures(id);
 	}
 	
-	/**
-	 * Bind this texture to its target.
-	 */
-	protected void bind() {
-		glBindTexture(target, id);
-	}
-	
-	/**
-	 * Set the currently active texture unit to the given textureSlot and binds this texture.
-	 * @param textureSlot The offset to be applied to GL_TEXTURE0 to set as the active texture unit.
-	 */
 	public void activate(int textureSlot) {
 		glActiveTexture(GL_TEXTURE0 + textureSlot);
 		bind();
 	}
 	
-	private void tex(Tex function) {
-		switch (function) {
-			case null -> {
-				// Skip nulls
-			}
-			case Parameter parameter -> texParameter(parameter);
-			case Image2D image2D -> texImage2D(image2D);
-		}
+	public void bind() {
+		glBindTexture(target, id);
 	}
 	
-	private void texParameter(TextureBuilder.Parameter parameter) {
-		switch (parameter) {
-			case Parameteri(int pname, int param) -> glTexParameteri(target, pname, param);
-			case Parameterf(int pname, float param) -> glTexParameterf(target, pname, param);
-		}
+	public void unbind() {
+		glBindTexture(target, 0);
 	}
 	
-	private void texImage2D(TextureBuilder.Image2D image) {
-		switch (image) {
-			case Texture2D<?> texture2D -> specifyTextureImage2D(texture2D);
-			case TextureCubeMapBuilder.TextureCubeMap textureCubeMap -> {
-				specifyTextureImage2D(textureCubeMap.positiveX, GL_TEXTURE_CUBE_MAP_POSITIVE_X);
-				specifyTextureImage2D(textureCubeMap.negativeX, GL_TEXTURE_CUBE_MAP_NEGATIVE_X);
-				specifyTextureImage2D(textureCubeMap.positiveY, GL_TEXTURE_CUBE_MAP_POSITIVE_Y);
-				specifyTextureImage2D(textureCubeMap.negativeY, GL_TEXTURE_CUBE_MAP_NEGATIVE_Y);
-				specifyTextureImage2D(textureCubeMap.positiveZ, GL_TEXTURE_CUBE_MAP_POSITIVE_Z);
-				specifyTextureImage2D(textureCubeMap.negativeZ, GL_TEXTURE_CUBE_MAP_NEGATIVE_Z);
-			}
-		}
-	}
-	
-	private <T extends Buffer> void specifyTextureImage2D(Texture2D<T> image, int target) {
-		if (image instanceof Texture2D(var level, var internalFormat, var width, var height, var format, var type, var pixels)) {
-			switch (pixels) {
-				case ByteBuffer b -> glTexImage2D(target, level, internalFormat, width, height, 0, format, type, b);
-				case DoubleBuffer d -> glTexImage2D(target, level, internalFormat, width, height, 0, format, type, d);
-				case FloatBuffer f -> glTexImage2D(target, level, internalFormat, width, height, 0, format, type, f);
-				case IntBuffer i -> glTexImage2D(target, level, internalFormat, width, height, 0, format, type, i);
-				case ShortBuffer s -> glTexImage2D(target, level, internalFormat, width, height, 0, format, type, s);
-				case null -> glTexImage2D(target, level, internalFormat, width, height, 0, format, type, MemoryUtil.NULL);
-				default -> throw new IllegalArgumentException("Cannot specify 2D texture with pixel data of type " + pixels.getClass());
-			}
-		}
-	}
-	
-	private <T extends Buffer> void specifyTextureImage2D(Texture2D<T> image) {
-		specifyTextureImage2D(image, target);
-	}
-	
-	/**
-	 * 
-	 */
-	public abstract static sealed class TextureBuilder<T extends TextureBuilder<T>> {
-		private static final Function<TextureBuilder<?>, Texture> TO_TEXTURE = TextureBuilder::build;
-		
-		private final int target;
-		private final Set<Parameter> parameters;
-		protected Image2D image2D;
+	public static abstract class Builder<SELF extends Builder<SELF>> {
+		protected final int target;
+		private final Set<Parameter> params;
+		protected TexImage texImage;
 		private boolean generateMipmap;
 		
-		/**
-		 * @param target
-		 */
-		private TextureBuilder(int target) {
+		protected Builder(int target) {
 			this.target = target;
-			parameters = new HashSet<>();
+			params = new HashSet<>();
 		}
 		
-		protected abstract T self();
+		protected abstract SELF self();
 		
-		/**
-		 * @return the constructed Texture with configurations applied
-		 */
-		public Texture build() {
-			return new Texture(this);
+		private Texture build() {
+			return new Texture(target, params, texImage, generateMipmap);
 		}
 		
-		/**
-		 * @param param
-		 * @return this
-		 */
-		public T minFilter(int param) {
-			parameters.add(Parameteri.minFilter(param));
-			return self();
-		}
-		
-		/**
-		 * @param param
-		 * @return this
-		 */
-		public T magFilter(int param) {
-			parameters.add(Parameteri.magFilter(param));
-			return self();
-		}
-		
-		/**
-		 * @return a Filter
-		 */
-		public Filter filter() {
-			return new Filter();
-		}
-		
-		/**
-		 *
-		 */
-		public class Filter {
-			private T apply(int param) {
-				minFilter(param);
-				magFilter(param);
-				return self();
-			}
+		public sealed interface TexImage {
+			public int level();
 			
-			/**
-			 * @return {@link TextureBuilder}
-			 */
-			public T nearest() {
-				return apply(GL_NEAREST);
-			}
+			public int internalFormat();
 			
-			/**
-			 * @return {@link TextureBuilder}
-			 */
-			public T linear() {
-				return apply(GL_LINEAR);
-			}
+			public int width();
+			
+			public int height();
+			
+			public int border();
+			
+			public int format();
+			
+			public int type();
 		}
 		
-		/**
-		 * @param param
-		 * @return this
-		 */
-		public T wrapS(int param) {
-			parameters.add(Parameteri.wrapS(param));
+		public SELF parameteri(int pname, int param) {
+			params.add(new Parameteri(pname, param));
 			return self();
 		}
 		
-		/**
-		 * @param param
-		 * @return this
-		 */
-		public T wrapT(int param) {
-			parameters.add(Parameteri.wrapT(param));
+		public SELF parameterf(int pname, float param) {
+			params.add(new Parameterf(pname, param));
 			return self();
 		}
 		
-		/**
-		 * @param param
-		 * @return this
-		 */
-		public T wrapR(int param) {
-			parameters.add(Parameteri.wrapR(param));
-			return self();
-		}
+		public sealed interface Parameter {}
 		
-		/**
-		 * @return this
-		 */
-		public Wrap wrap2D() {
-			return new Wrap2D();
-		}
-
-		/**
-		 * @return this
-		 */
-		public Wrap wrap3D() {
-			return new Wrap3D();
-		}
-		
-		public abstract sealed class Wrap {
-			protected abstract T apply(int param);
-			
-			/**
-			 * @return TextureBuilder
-			 */
-			public T repeat() {
-				return apply(GL_REPEAT);
-			}
-			
-			/**
-			 * @return TextureBuilder
-			 */
-			public T clampToEdge() {
-				return apply(GL_CLAMP_TO_EDGE);
-			}
-		}
-		
-		/**
-		 *
-		 */
-		public final class Wrap2D extends Wrap {
+		public record Parameteri(int pname, int param) implements Parameter {
 			@Override
-			protected T apply(int param) {
-				wrapS(param);
-				wrapT(param);
-				return self();
+			public int hashCode() {
+				return Objects.hash(pname);
 			}
-			
-		}
-		
-		/**
-		 *
-		 */
-		public final class Wrap3D extends Wrap {
-			@Override
-			protected T apply(int param) {
-				wrapS(param);
-				wrapT(param);
-				wrapR(param);
-				return self();
-			}
-		}
-		
-		/**
-		 * @return this
-		 */
-		public T anisotropicFiltering() {
-			if (GL.getCapabilities().GL_EXT_texture_filter_anisotropic) {
-				// TODO#40: Extract some global Anisotropic filtering value
-				float amount = Math.min(4f, glGetFloat(EXTTextureFilterAnisotropic.GL_MAX_TEXTURE_MAX_ANISOTROPY_EXT));
-				parameters.add(new Parameterf(EXTTextureFilterAnisotropic.GL_TEXTURE_MAX_ANISOTROPY_EXT, amount));
-			}
-			return self();
-		}
 
-		public sealed interface Tex {
-			
-		}
-		
-		public sealed interface Image2D extends Tex {}
-		
-		/**
-		 * @param <T>
-		 * @param level 
-		 * @param internalFormat 
-		 * @param width 
-		 * @param height 
-		 * @param format 
-		 * @param type 
-		 * @param pixels 
-		 */
-		public record Texture2D<T extends Buffer>(int level, int internalFormat, int width, int height, int format, int type, T pixels) implements Image2D {
-			/**
-			 * @param width
-			 * @param height
-			 * @param format
-			 * @param pixels
-			 */
-			public Texture2D(int width, int height, int format, T pixels) {
-				this(0, internalFormat(format), width, height, format, GL_UNSIGNED_BYTE, pixels);
-			}
-			
-			/**
-			 * @param imageData
-			 * @return a {@link Texture2D} allocated from imageData.
-			 */
-			public static Texture2D<ByteBuffer> fromImage(ImageData imageData) {
-				return new Texture2D<>(imageData.width(), imageData.height(), parseFormat(imageData.channels()), imageData.pixels());
-			}
-			
-			private static int parseFormat(int channels) {
-				return switch (channels) {
-					case 1 -> GL_RED;
-					case 3 -> GL_RGB;
-					case 4 -> GL_RGBA;
-					default -> {
-						AvoLog.log().warn("Image was loaded with channel count: [{}] defaulting to GL_RED.", channels);
-						yield GL_RED;
-					}
-				};
-			}
-			
-			private static int internalFormat(int format) {
-				return switch (format) {
-					case GL_RGBA -> GL_RGBA8;
-					default -> format;
-				};
+			@Override
+			public boolean equals(Object obj) {
+				if (this == obj)
+					return true;
+				if (!(obj instanceof Parameteri))
+					return false;
+				Parameteri other = (Parameteri) obj;
+				return pname == other.pname;
 			}
 		}
 		
-		/**
-		 * @return this
-		 */
-		public T generateMipmap() {
+		public record Parameterf(int pname, float param) implements Parameter {
+			@Override
+			public int hashCode() {
+				return Objects.hash(pname);
+			}
+
+			@Override
+			public boolean equals(Object obj) {
+				if (this == obj)
+					return true;
+				if (!(obj instanceof Parameterf))
+					return false;
+				Parameterf other = (Parameterf) obj;
+				return pname == other.pname;
+			}
+		}
+		
+		public MinFilter minFilter() {
+			return new MinFilter();
+		}
+		
+		public MagFilter magFilter() {
+			return new MagFilter();
+		}
+		
+		public abstract sealed class FilterParam {
+			public abstract SELF function(int function);
+			
+			public SELF nearest() {
+				return function(GL_NEAREST);
+			}
+			
+			public SELF linear() {
+				return function(GL_LINEAR);
+			}
+		}
+		
+		public final class MinFilter extends FilterParam {
+			@Override
+			public SELF function(int function) {
+				return Builder.this.parameteri(GL_TEXTURE_MIN_FILTER, function);
+			}
+			
+			public SELF nearestMipmapNearest() {
+				return function(GL_NEAREST_MIPMAP_NEAREST);
+			}
+
+			public SELF linearMipmapNearest() {
+				return function(GL_LINEAR_MIPMAP_NEAREST);
+			}
+
+			public SELF nearestMipmapLinear() {
+				return function(GL_NEAREST_MIPMAP_LINEAR);
+			}
+
+			public SELF linearMipmapLinear() {
+				return function(GL_LINEAR_MIPMAP_LINEAR);
+			}
+		}
+		
+		public final class MagFilter extends FilterParam {
+			@Override
+			public SELF function(int function) {
+				return Builder.this.parameteri(GL_TEXTURE_MAG_FILTER, function);
+			}
+		}
+		
+		public WrapS wrapS() {
+			return new WrapS();
+		}
+		
+		public WrapT wrapT() {
+			return new WrapT();
+		}
+		
+		public WrapR wrapR() {
+			return new WrapR();
+		}
+		
+		public WrapST wrapST() {
+			return new WrapST();
+		}
+		
+		public WrapSTR wrapSTR() {
+			return new WrapSTR();
+		}
+		
+		public abstract sealed class WrapParam {
+			protected abstract SELF set(int param);
+			
+			public SELF clampToEdge() {
+				return set(GL_CLAMP_TO_EDGE);
+			}
+			
+			public SELF clampToBorder() {
+				return set(GL_CLAMP_TO_BORDER);
+			}
+			
+			public SELF mirroredRepeat() {
+				return set(GL_MIRRORED_REPEAT);
+			}
+			
+			public SELF repeat() {
+				return set(GL_REPEAT);
+			}
+		}
+		
+		public sealed class WrapS extends WrapParam {
+			@Override
+			protected SELF set(int param) {
+				return Builder.this.parameteri(GL_TEXTURE_WRAP_S, param);
+			}
+		}
+		
+		public final class WrapT extends WrapParam {
+			@Override
+			protected SELF set(int param) {
+				return Builder.this.parameteri(GL_TEXTURE_WRAP_T, param);
+			}
+		}
+		
+		public final class WrapR extends WrapParam {
+			@Override
+			protected SELF set(int param) {
+				return Builder.this.parameteri(GL_TEXTURE_WRAP_R, param);
+			}
+		}
+		
+		public sealed class WrapST extends WrapS {
+			@Override
+			protected SELF set(int param) {
+				return super.set(param).parameteri(GL_TEXTURE_WRAP_T, param);
+			}
+		}
+		
+		public final class WrapSTR extends WrapST {
+			@Override
+			protected SELF set(int param) {
+				return super.set(param).parameteri(GL_TEXTURE_WRAP_R, param);
+			}
+		}
+		
+		public SELF generateMipmap() {
 			generateMipmap = true;
 			return self();
 		}
 		
-		public sealed interface Parameter extends Tex {}
-		
-		/**
-		 * TODO#40 Validate the param value against the pname
-		 * @param pname
-		 * @param param
-		 */
-		public static record Parameteri(int pname, int param) implements Parameter {
-			/**
-			 * @param param
-			 * @return a GL_TEXTURE_MIN_FILTER parameter.
-			 */
-			public static Parameteri minFilter(int param) {
-				return new Parameteri(GL_TEXTURE_MIN_FILTER, param);
+		public SELF anisotropicFiltering(float amount) {
+			if (GL.getCapabilities().GL_EXT_texture_filter_anisotropic) {
+				amount = Math.min(amount, glGetFloat(EXTTextureFilterAnisotropic.GL_MAX_TEXTURE_MAX_ANISOTROPY_EXT));
+				parameterf(EXTTextureFilterAnisotropic.GL_TEXTURE_MAX_ANISOTROPY_EXT, amount);
 			}
-			
-			/**
-			 * @param param
-			 * @return a GL_TEXTURE_MAG_FILTER parameter.
-			 */
-			public static Parameteri magFilter(int param) {
-				return new Parameteri(GL_TEXTURE_MAG_FILTER, param);
-			}
-			
-			/**
-			 * @param param
-			 * @return a GL_TEXTURE_WRAP_S parameter.
-			 */
-			public static Parameteri wrapS(int param) {
-				return new Parameteri(GL_TEXTURE_WRAP_S, param);
-			}
-			
-			/**
-			 * @param param
-			 * @return a GL_TEXTURE_WRAP_T parameter.
-			 */
-			public static Parameteri wrapT(int param) {
-				return new Parameteri(GL_TEXTURE_WRAP_T, param);
-			}
-			
-			/**
-			 * @param param
-			 * @return a GL_TEXTURE_WRAP_R parameter.
-			 */
-			public static Parameteri wrapR(int param) {
-				return new Parameteri(GL_TEXTURE_WRAP_R, param);
-			}
-			
-			@Override
-			public final int hashCode() {
-				return pname;
-			}
+			return self();
 		}
 		
-		/**
-		 *
-		 * @param pname
-		 * @param param
-		 */
-		public static record Parameterf(int pname, float param) implements Parameter {
-			@Override
-			public final int hashCode() {
-				return pname;
-			}
+		public SELF anisotropicFiltering() {
+			// TODO#40: Extract some global Anisotropic filtering value
+			return anisotropicFiltering(4f);
 		}
 	}
 	
-	/**
-	 *
-	 */
-	public static final class Texture2DBuilder extends TextureBuilder<Texture2DBuilder> {
-		private Texture2DBuilder() {
+	public static final class Texture2DBuilder extends Builder<Texture2DBuilder> {
+		protected Texture2DBuilder() {
 			super(GL_TEXTURE_2D);
 		}
-		
+
 		@Override
 		protected Texture2DBuilder self() {
 			return this;
 		}
-		
-		/**
-		 * @param imageData 
-		 * @return this
-		 */
-		public Texture2DBuilder image2D(ImageData imageData) {
-			this.image2D = Texture2D.fromImage(imageData);
-			return this;
-		}
-		
-		/**
-		 * @param <T>
-		 * @param level
-		 * @param internalFormat
-		 * @param width
-		 * @param height
-		 * @param format
-		 * @param type
-		 * @param pixels
-		 * @return this
-		 */
-		public <T extends Buffer> Texture2DBuilder image2D(int level, int internalFormat, int width, int height, int format, int type, T pixels) {
-			this.image2D = new Texture2D<>(level, internalFormat, width, height, format, type, pixels);
-			return this;
-		}
 
-		/**
-		 * @param <T>
-		 * @param internalFormat
-		 * @param width
-		 * @param height
-		 * @param format
-		 * @param type
-		 * @param pixels
-		 * @return this
-		 */
-		public <T extends Buffer> Texture2DBuilder image2D(int internalFormat, int width, int height, int format, int type, T pixels) {
-			return image2D(0, internalFormat, width, height, format, type, pixels);
+		public Texture2DBuilder image2D(Consumer<Texture2DBuilder> builder) {
+			builder.accept(this);
+			return self();
 		}
 		
-		/**
-		 * @param <T>
-		 * @param width
-		 * @param height
-		 * @param format
-		 * @param pixels
-		 * @return this
-		 */
-		public <T extends Buffer> Texture2DBuilder image2D(int width, int height, int format, T pixels) {
-			return image2D(Texture2D.internalFormat(format), width, height, format, GL_UNSIGNED_BYTE, pixels);
+		public <T extends Buffer> Texture2DBuilder image2D(int level, int internalFormat, int width, int height, int format, int type, T pixels) {
+			this.texImage = new TexImage2D<>(level, internalFormat, width, height, 0, format, type, pixels);
+			return self();
 		}
 		
-		/**
-		 * @param <T>
-		 * @param width
-		 * @param height
-		 * @param pixels
-		 * @return this
-		 */
-		public <T extends Buffer> Texture2DBuilder image2D(int width, int height, T pixels) {
-			return image2D(width, height, GL_RED, pixels);
+		public Texture2DBuilder image2D(int level, int internalFormat, int width, int height, int format, ByteBuffer pixels) {
+			this.texImage = new TexImage2D<>(level, internalFormat, width, height, 0, format, GL_UNSIGNED_BYTE, pixels);
+			return self();
 		}
+		
+		public Texture2DBuilder image2D(int width, int height, int format, ByteBuffer pixels) {
+			return image2D(0, format, width, height, format, pixels);
+		}
+		
+		public Texture2DBuilder image2D(int width, int height, int format) {
+			return image2D(width, height, format, (ByteBuffer) null);
+		}
+		
+		public record TexImage2D<T extends Buffer>(int level, int internalFormat, int width, int height, int border, int format, int type, T pixels) implements TexImage {}
 	}
 	
-	/**
-	 *
-	 */
-	public static final class TextureCubeMapBuilder extends TextureBuilder<TextureCubeMapBuilder> {
-		private TextureCubeMapBuilder() {
+	public static final class TextureCubeMapBuilder extends Builder<TextureCubeMapBuilder> {
+		protected TextureCubeMapBuilder() {
 			super(GL_TEXTURE_CUBE_MAP);
 		}
-		
+
 		@Override
 		protected TextureCubeMapBuilder self() {
 			return this;
 		}
 		
-		/**
-		 * @return a textureCubeMap
-		 */
-		public TextureCubeMap image2D() {
-			return new TextureCubeMap();
+		public TextureCubeMapBuilder cubeMap(Consumer<TextureCubeMapBuilder> builder) {
+			builder.accept(this);
+			return self();
 		}
 		
-		/**
-		 *
-		 */
-		public final class TextureCubeMap implements Image2D {
-			private Texture2D<? extends Buffer> positiveX;
-			private Texture2D<? extends Buffer> negativeX;
-			private Texture2D<? extends Buffer> positiveY;
-			private Texture2D<? extends Buffer> negativeY;
-			private Texture2D<? extends Buffer> positiveZ;
-			private Texture2D<? extends Buffer> negativeZ;
-			
-			/**
-			 * @param <T>
-			 * @param positiveX
-			 * @param negativeX
-			 * @param positiveY
-			 * @param negativeY
-			 * @param positiveZ
-			 * @param negativeZ
-			 * @return TextureCubeMapBuilder
-			 */
-			public <T extends Buffer> TextureCubeMapBuilder cubeMap(Texture2D<T> positiveX, Texture2D<T> negativeX, Texture2D<T> positiveY, Texture2D<T> negativeY, Texture2D<T> positiveZ, Texture2D<T> negativeZ) {
-				this.positiveX = positiveX;
-				this.negativeX = negativeX;
-				this.positiveY = positiveY;
-				this.negativeY = negativeY;
-				this.positiveZ = positiveZ;
-				this.negativeZ = negativeZ;
-				image2D = this;
-				return TextureCubeMapBuilder.this;
-			}
-			
-			/**
-			 * @param positiveX
-			 * @param negativeX
-			 * @param positiveY
-			 * @param negativeY
-			 * @param positiveZ
-			 * @param negativeZ
-			 * @return TextureCubeMapBuilder
-			 */
-			public TextureCubeMapBuilder cubeMap(ImageData positiveX, ImageData negativeX, ImageData positiveY, ImageData negativeY, ImageData positiveZ, ImageData negativeZ) {
-				return cubeMap(Texture2D.fromImage(positiveX), Texture2D.fromImage(negativeX), Texture2D.fromImage(positiveY), Texture2D.fromImage(negativeY), Texture2D.fromImage(positiveZ), Texture2D.fromImage(negativeZ));
-			}
-			
-			/**
-			 * @param <T>
-			 * @param texture2D
-			 * @return TextureCubeMapBuilder
-			 */
-			public <T extends Buffer> TextureCubeMapBuilder cubeMap(Texture2D<T> texture2D) {
-				return cubeMap(texture2D, texture2D, texture2D, texture2D, texture2D, texture2D);
-			}
-			
-			/**
-			 * @param imageData
-			 * @return TextureCubeMapBuilder
-			 */
-			public TextureCubeMapBuilder cubeMap(ImageData imageData) {
-				return cubeMap(Texture2D.fromImage(imageData));
-			}
-			
-			/**
-			 * @param <T>
-			 * @param width
-			 * @param height
-			 * @param format
-			 * @param pixels
-			 * @return TextureCubeMapBuilder
-			 */
-			public <T extends Buffer> TextureCubeMapBuilder cubeMap(int width, int height, int format, T pixels) {
-				return cubeMap(new Texture2D<>(width, height, format, pixels));
+		public TextureCubeMapBuilder cubeMap(int width, int height, int format,
+				ByteBuffer positiveX, ByteBuffer negativeX, ByteBuffer positiveY, ByteBuffer negativeY, ByteBuffer positiveZ, ByteBuffer negativeZ) {
+			this.texImage = new TexImageCubeMap(0, format, width, height, 0, format, GL_UNSIGNED_BYTE, new ByteBuffer[] { positiveX, negativeX, positiveY, negativeY, positiveZ, negativeZ });
+			return self();
+		}
+		
+		public TextureCubeMapBuilder cubeMap(int width, int height, int format, ByteBuffer allFaces) {
+			return cubeMap(width, height, format, allFaces, allFaces, allFaces, allFaces, allFaces, allFaces);
+		}
+
+		public TextureCubeMapBuilder cubeMap(int width, int height, int format) {
+			return cubeMap(width, height, format, (ByteBuffer) null);
+		}
+		
+		public record TexImageCubeMap(int level, int internalFormat, int width, int height, int border, int format, int type, ByteBuffer[] pixels) implements TexImage {
+			public TexImageCubeMap {
+				if (Objects.requireNonNull(pixels).length != 6) {
+					throw new IllegalArgumentException("CubeMap must specify 6 image buffers.");
+				}
 			}
 		}
 	}

--- a/base/src/main/java/com/avogine/render/opengl/texture/data/Image.java
+++ b/base/src/main/java/com/avogine/render/opengl/texture/data/Image.java
@@ -1,0 +1,100 @@
+package com.avogine.render.opengl.texture.data;
+
+import static org.lwjgl.opengl.GL11C.*;
+import static org.lwjgl.opengl.GL30C.GL_RG;
+
+import java.nio.ByteBuffer;
+import java.util.function.Consumer;
+
+import com.avogine.render.image.data.ImageData;
+import com.avogine.render.opengl.texture.Texture.*;
+
+/**
+ *
+ */
+public sealed interface Image {
+	/**
+	 * @param channels
+	 * @return a texel format based on the number of channels in the image.
+	 */
+	private static int parseFormat(int channels) {
+		return switch (channels) {
+			case 1 -> GL_RED;
+			case 2 -> GL_RG;
+			case 3 -> GL_RGB;
+			default -> GL_RGBA;
+		};
+	}
+	
+	/**
+	 * @return the width of the image in pixels.
+	 */
+	public int width();
+	
+	/**
+	 * @return the height of the image in pixels.
+	 */
+	public int height();
+	
+	/**
+	 * @return the texel data format.
+	 */
+	public int format();
+	
+	/**
+	 *
+	 * @param width 
+	 * @param height 
+	 * @param format 
+	 * @param pixelData
+	 */
+	public record Image2D(int width, int height, int format, ByteBuffer pixelData) implements Image, Consumer<Texture2DBuilder> {
+		/**
+		 * @param imageData
+		 * @return an {@link Image2D} wrapping the image data.
+		 */
+		public static Image2D of(ImageData imageData) {
+			return new Image2D(imageData.width(), imageData.height(), Image.parseFormat(imageData.channels()), imageData.pixels());
+		}
+		
+		@Override
+		public void accept(Texture2DBuilder builder) {
+			builder.image2D(width, height, format, pixelData);
+		}
+	}
+
+	/**
+	 *
+	 * @param width 
+	 * @param height 
+	 * @param format 
+	 * @param positiveX
+	 * @param negativeX
+	 * @param positiveY
+	 * @param negativeY
+	 * @param positiveZ
+	 * @param negativeZ
+	 */
+	public record CubeMap(int width, int height, int format,
+			ByteBuffer positiveX, ByteBuffer negativeX, ByteBuffer positiveY, ByteBuffer negativeY, ByteBuffer positiveZ, ByteBuffer negativeZ) implements Image, Consumer<TextureCubeMapBuilder> {
+		/**
+		 * @param positiveX
+		 * @param negativeX
+		 * @param positiveY
+		 * @param negativeY
+		 * @param positiveZ
+		 * @param negativeZ
+		 * @return a {@link CubeMap} wrapping each image data.
+		 */
+		public static CubeMap of(ImageData positiveX, ImageData negativeX, ImageData positiveY, ImageData negativeY, ImageData positiveZ, ImageData negativeZ) {
+			return new CubeMap(positiveX.width(), positiveX.height(), Image.parseFormat(positiveX.channels()),
+					positiveX.pixels(), negativeX.pixels(), positiveY.pixels(), negativeY.pixels(), positiveZ.pixels(), negativeZ.pixels());
+		}
+		
+		@Override
+		public void accept(TextureCubeMapBuilder builder) {
+			builder.cubeMap(width, height, format, positiveX, negativeX, positiveY, negativeY, positiveZ, negativeZ);
+		}
+	}
+
+}

--- a/base/src/main/java/com/avogine/render/opengl/texture/util/TextureLoader.java
+++ b/base/src/main/java/com/avogine/render/opengl/texture/util/TextureLoader.java
@@ -9,6 +9,7 @@ import org.lwjgl.system.MemoryStack;
 import com.avogine.render.image.data.ImageData;
 import com.avogine.render.image.util.ImageLoader;
 import com.avogine.render.opengl.texture.Texture;
+import com.avogine.render.opengl.texture.data.Image.*;
 
 /**
  *
@@ -38,8 +39,9 @@ public class TextureLoader {
 			pixels.flip();
 			
 			return Texture.gen2D(tex -> tex
-					.filter().linear()
-					.wrap2D().repeat()
+					.minFilter().linear()
+					.magFilter().linear()
+					.wrapST().repeat()
 					.image2D(width, height, GL_RGBA, pixels));
 		}
 	}
@@ -49,11 +51,12 @@ public class TextureLoader {
 	 * @return
 	 */
 	public static Texture loadTexture(String texturePath) {
-		try (ImageData imageData = ImageLoader.loadImage(texturePath)) {
+		try (ImageData image = ImageLoader.loadImage(texturePath)) {
 			return Texture.gen2D(tex -> tex
-					.filter().linear()
-					.wrap2D().repeat()
-					.image2D(imageData)
+					.minFilter().linear()
+					.magFilter().linear()
+					.wrapST().repeat()
+					.image2D(Image2D.of(image))
 					.generateMipmap()
 					.anisotropicFiltering());
 		}
@@ -76,14 +79,10 @@ public class TextureLoader {
 				ImageData posZImageData = ImageLoader.loadImage(posZImagePath);
 				ImageData negZImageData = ImageLoader.loadImage(negZImagePath);) {
 			return Texture.genCubeMap(tex -> tex
-					.filter().linear()
-					.wrap3D().clampToEdge()
-					.image2D().cubeMap(posXImageData,
-							negXImageData,
-							posYImageData,
-							negYImageData,
-							posZImageData,
-							negZImageData));
+					.minFilter().linear()
+					.magFilter().linear()
+					.wrapSTR().clampToEdge()
+					.cubeMap(CubeMap.of(posXImageData, negXImageData, posYImageData, negYImageData, posZImageData, negZImageData)));
 		}
 	}
 	

--- a/base/src/main/java/com/avogine/render/opengl/ui/NuklearRender.java
+++ b/base/src/main/java/com/avogine/render/opengl/ui/NuklearRender.java
@@ -72,7 +72,7 @@ public class NuklearRender {
 		glDisable(GL_CULL_FACE);
 		glDisable(GL_DEPTH_TEST);
 		glEnable(GL_SCISSOR_TEST);
-		glActiveTexture(GL13.GL_TEXTURE0);
+		glActiveTexture(GL13C.GL_TEXTURE0);
 	}
 	
 	private void teardownUIState() {

--- a/base/src/main/java/com/avogine/render/opengl/ui/TextRender.java
+++ b/base/src/main/java/com/avogine/render/opengl/ui/TextRender.java
@@ -1,6 +1,6 @@
 package com.avogine.render.opengl.ui;
 
-import static org.lwjgl.opengl.GL11.*;
+import static org.lwjgl.opengl.GL11C.*;
 
 import java.nio.FloatBuffer;
 

--- a/base/src/main/java/com/avogine/render/opengl/ui/nuklear/NuklearMesh.java
+++ b/base/src/main/java/com/avogine/render/opengl/ui/nuklear/NuklearMesh.java
@@ -86,7 +86,8 @@ public class NuklearMesh {
 		// null texture setup
 		try (MemoryStack stack = stackPush()) {
 			int nullTexID = Texture.gen2D(nullTex -> nullTex
-					.filter().nearest()
+					.minFilter().nearest()
+					.magFilter().nearest()
 					.image2D(0, GL_RGBA8, 1, 1, GL_RGBA, GL_UNSIGNED_INT_8_8_8_8_REV, stack.ints(0xFFFFFFFF)))
 			.id();
 

--- a/ecs/src/test/java/com/avogine/ecs/TestECSRender.java
+++ b/ecs/src/test/java/com/avogine/ecs/TestECSRender.java
@@ -6,7 +6,7 @@ import com.avogine.render.SceneRender;
 /**
  *
  */
-public class TestECSRender implements SceneRender<TestECSScene> {
+public class TestECSRender extends SceneRender<TestECSScene> {
 
 	@Override
 	public void render(Window window, TestECSScene scene) {

--- a/pom.xml
+++ b/pom.xml
@@ -36,12 +36,16 @@
   </properties>
   
   <build>
+	<pluginManagement>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<version>3.14.0</version>
+			</plugin>
+		</plugins>
+	</pluginManagement>
 	<plugins>
-		<plugin>
-			<groupId>org.apache.maven.plugins</groupId>
-			<artifactId>maven-compiler-plugin</artifactId>
-			<version>3.14.0</version>
-		</plugin>
 		<plugin>
 			<groupId>org.apache.maven.plugins</groupId>
 			<artifactId>maven-enforcer-plugin</artifactId>


### PR DESCRIPTION
Refactored `Texture` to provide a more streamlined builder pattern for constructing OpenGL Texture objects.

This includes better memory management around loaded images from either the file system or dynamically allocated in memory.

A new `Render` class was added for tracking global state of rendering specific settings, currently this only applies to Anisotropic Filtering, but can be expanded to any render "quality" settings.

Closes #40 